### PR TITLE
add delete_tasks.py to delete drafts and/or abort queued/running tasks

### DIFF
--- a/scripts/delete_tasks.py
+++ b/scripts/delete_tasks.py
@@ -1,0 +1,84 @@
+import click
+from sevenbridges.errors import SbgError, NotFound
+from helper_functions import helper_functions as hf
+
+CONTEXT_SETTINGS = dict(help_option_names=["-h", "--help"])
+
+ACTIVE_STATI = {"QUEUED", "RUNNING"}
+DRAFT_STATI = {"DRAFT"}
+
+
+@click.command(context_settings=CONTEXT_SETTINGS, no_args_is_help=True)
+@click.option(
+    "--project", help="Project the app is in, first two '/'s after 'u/' in Cavatica url"
+)
+@click.option(
+    "--profile",
+    help="Profile to use from credentials file",
+    default="cavatica",
+    show_default=True,
+)
+@click.option("--run", help="Run the task", is_flag=True, default=False)
+def delete_tasks(profile, project, run):
+    """
+    Find DRAFT and/or active (QUEUED/RUNNING) tasks and/or delete/abort them.:
+      - delete DRAFT tasks
+      - abort active tasks
+    """
+    # Auth
+    api = hf.parse_config(profile)
+
+    # Discover tasks
+    all_tasks = hf.get_all_tasks(api, project)
+
+    draft_tasks = []
+    active_tasks = []
+    for task in all_tasks:
+        status = (task.status or "").upper()
+        if status in DRAFT_STATI:
+            draft_tasks.append(task)
+        elif status in ACTIVE_STATI:
+            active_tasks.append(task)
+
+    click.echo(
+        f"Found {len(draft_tasks)} DRAFT tasks and {len(active_tasks)} active tasks (QUEUED/RUNNING)."
+    )
+
+    # Preview
+    if draft_tasks:
+        click.echo("\n[DRAFT] Tasks to delete:")
+        for t in draft_tasks:
+            click.echo(f"{t.id}, {t.name}, {t.status}")
+    if active_tasks:
+        click.echo("\n[ACTIVE] Tasks to abort:")
+        for t in active_tasks:
+            click.echo(f"{t.id}, {t.name}, {t.status}")
+
+    if not run:
+        click.echo("\n[dry-run] No actions taken. Re-run with --run to apply.")
+        click.echo("Done!")
+        return
+
+    # Delete drafts
+    for t in draft_tasks:
+        try:
+            click.echo(f"[delete] DRAFT {t.id} — {t.name}")
+            t.delete()
+        except NotFound:
+            click.echo(f"[skip] DRAFT {t.id} already deleted, skipping")
+        except SbgError as e:
+            click.echo(f"[error] Failed to delete DRAFT {t.id}: {e}")
+
+    # Abort active
+    for t in active_tasks:
+        try:
+            click.echo(f"[abort] {t.status} {t.id} — {t.name}")
+            t.abort()
+        except SbgError as e:
+            click.echo(f"[error] Failed to abort {t.id}: {e}")
+
+    click.echo("Done!")
+
+
+if __name__ == "__main__":
+    delete_tasks()


### PR DESCRIPTION
<!--Hi there, thanks for your contribution! Please take a moment to fill out this template to facilitate the review of your pull request.-->

### Purpose/implementation Section
```
Usage:
  python scripts/delete_tasks.py --project "org/project"                # dry-run
  python scripts/delete_tasks.py --project "org/project" --profile turbo/cavatica --run # apply
```

#### What GitHub issue does your pull request address?

issue #28 

#### Is there anything that you want to discuss further?

is there a limit on how many tasks can be deleted/ aborted ? 

#### Test

- tested on Fisher_WGS_harmonization: https://cavatica.sbgenomics.com/u/childrens-bti/fisher-wgs-harmonization/tasks

- dry-run command:

`python scripts/delete_tasks.py --project "childrens-bti/fisher-wgs-harmonization" --profile turbo`

- output:

```
Found 1 DRAFT tasks and 44 active tasks (QUEUED/RUNNING).

[DRAFT] Tasks to delete:
9c42e31a-91bb-4f41-9b89-a745eb5967d7, Kids First DRC Sentieon Alignment and gVCF Workflow run - 10-31-25 17:25:44, DRAFT

[ACTIVE] Tasks to abort:
c8f8cd49-ae45-4eb2-ba85-befb40766e96, kfdrc_sentieon_alignment_wf_20251031_BA_9X3NH326_20251031, RUNNING
... 

[dry-run] No actions taken. Re-run with --run to apply.
Done!

```

#### Reproducibility Checklist

<!-- Check all those that apply or remove this section if it is not applicable.-->

- [ ] The dependencies required to run the code in this pull request have been added to the project Dockerfile.

#### Documentation Checklist

- [ ] The analytical code is documented and contains comments.
