### PR TITLE
only launch a set number of tasks at a time and monitor them until done

### DIFF
--- a/scripts/run_tasks.py
+++ b/scripts/run_tasks.py
@@ -2,6 +2,7 @@
 
 import click
 import configparser
+import time
 from pathlib import Path
 from sevenbridges import Api
 from helper_functions import helper_functions as hf
@@ -18,8 +19,34 @@ CONTEXT_SETTINGS = dict(help_option_names=["-h", "--help"])
     default="cavatica",
     show_default=True,
 )
-@click.option("--run", help="Run the task", is_flag=True, default=False)
-def launch_task(task_file, task_id, profile, run):
+@click.option(
+    "--limit",
+    help="Limit number of tasks to run at once, set to -1 to run all task (not recommended)",
+    default=50,
+    type=int,
+    show_default=True,
+)
+@click.option(
+    "--wait",
+    help="Time in minutes to wait between checking task status",
+    default=60,
+    type=int,
+    show_default=True,
+)
+@click.option(
+    "--max_checks",
+    help="Maximum number of status checks to perform",
+    default=12,
+    type=int,
+    show_default=True,
+)
+@click.option(
+    "--output_basename",
+    help="Base name for output files",
+    default="task_status",
+    show_default=True,
+)
+def launch_task(task_file, task_id, profile, limit, wait, max_checks, output_basename):
     """
     Launch a single task using the task id or
     launch multiple tasks getting the task ids from input file.
@@ -28,36 +55,90 @@ def launch_task(task_file, task_id, profile, run):
     """
     # read config file
     api = hf.parse_config(profile)
+
+    # figure out which tasks to run
+    all_tasks = []
     if task_file and task_id:
         print("ERROR: Please provide either a task file or a task id")
         exit(1)
     elif task_id:
         print(f"Current task id: {task_id}")
+        all_tasks = [task_id]
         task = api.tasks.get(id=task_id)
         print(f"Current status: {task.status}")
-        if run:
-            task.run()
-            print(f"Updated status: {task.status}")
-            print("Task successfully launched")
-        else:
-            print("Task was not launched")
     elif task_file:
         print(f"Launching tasks from file: {task_file}")
         with open(task_file, "r") as f:
-            for line in f:
-                task_id = line.strip()
-                print(f"Current task id: {task_id}")
+            all_tasks = [line.strip() for line in f]
+    else:
+        print("ERROR: Please provide either a task file or a task id")
+        exit(1)
+
+    # start running tasks and keeping track of completed and failed tasks
+    run_tasks = True
+    completed_tasks = []
+    failed_tasks = []
+    print(f"Running up to {limit} tasks at once")
+    while run_tasks:
+        # figure out how many tasks we're running this round
+        running_tasks = 0
+        if limit == -1:
+            tasks_to_run = all_tasks
+            # is this message correct?
+            print("Launching all tasks, status must be monitored manually")
+        else:
+            # this makes tasks_to_run the next 'limit' (ie 50) tasks from all_tasks
+            tasks_to_run = all_tasks[:limit]
+
+        running_tasks = []
+        failed_tasks = []
+        completed_tasks = []
+
+        # run tasks
+        print(f"Launching a batch of {limit} tasks")
+        for task_id in tasks_to_run:
+            task = api.tasks.get(id=task_id)
+            if task.status == "DRAFT" and len(running_tasks) < limit:
+                try:
+                    task.run()
+                    running_tasks.append(task_id)
+                except Exception as e:
+                    print(f"An error occurred launching this task: {e}")
+                    failed_tasks.append(task_id)
+
+        # check if the tasks are still running
+        checks = 0
+        while running_tasks and checks < max_checks:
+            checks += 1
+            print(f"Waiting {wait} minutes before checking task status...")
+            time.sleep(wait * 60)
+            for task_id in running_tasks[:]:
                 task = api.tasks.get(id=task_id)
-                print(f"Current status: {task.status}")
-                if run and task.status == "DRAFT":
-                    try:
-                        task.run()
-                        print(f"Updated status: {task.status}")
-                        print("Task successfully launched")
-                    except Exception as e:
-                        print(f"An error occurred launching this task: {e}")
-                else:
-                    print("Task was not launched")
+                if task.status == "COMPLETED":
+                    completed_tasks.append(task_id)
+                    running_tasks.remove(task_id)
+                elif task.status == "FAILED":
+                    failed_tasks.append(task_id)
+                    running_tasks.remove(task_id)
+
+        # write tasks to files based on status
+        with open(f"{output_basename}_completed.txt", "a") as comp_f:
+            for task_id in completed_tasks:
+                comp_f.write(f"{task_id}\n")
+        with open(f"{output_basename}_failed.txt", "a") as fail_f:
+            for task_id in failed_tasks:
+                fail_f.write(f"{task_id}\n")
+
+        if checks == max_checks:
+            print("Maximum number of checks reached, tasks may be stalled. Consider cancelling.")
+            exit(1)
+
+        # remove these tasks and repeat
+        all_tasks = all_tasks[limit:]
+        if not all_tasks:
+            run_tasks = False
+
+    print("All tasks processed")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This PR updates the `run_tasks.py` to only launch a limited number of tasks (default 50) at a time, monitors each batch, and launches another batch until all tasks are done running. This adds a new set of options: 

1. `--limit`: the number of tasks to launch in each batch
2. `--wait`: the number of minutes to wait before checking on the status of the tasks
3. `--max_checks`: the amount of times the script will check the tasks status before erroring out. This ensures that if a task is stuck on Cavatica for some reason that the script will eventually end and let you know you have to check Cavatica.
4. `--output_basename`: the output_basename for 2 new output files. The two files are list of completed and failed task ids.

Basically, the way tasks should be completed is by making an input file, creating a large number of tasks using the `create_task_from_wf_cwl.py`, then running this script using the task ids created by the create script. If there are a large number of tasks or the tasks will run for a long time, you should probably run this on the hpcc or somewhere else that will stay active longer than your personal machine.