### PR TITLE
:art: only drop columns from manifest if they exist

### DIFF
--- a/scripts/add_metatdata.py
+++ b/scripts/add_metatdata.py
@@ -52,11 +52,13 @@ def get_task_files(task) -> list:
     "--manifest",
     "-m",
     help="Input Manifest file",
+    required=True,
 )
 @click.option(
     "--output_file",
     "-o",
     help="Output filename",
+    required=True,
 )
 @click.option("--debug", help="Print some debug messages", is_flag=True, default=False)
 def add_metadata(profile, project, task_file, manifest, output_file, debug):
@@ -126,11 +128,21 @@ def add_metadata(profile, project, task_file, manifest, output_file, debug):
             sample_name = None
             matches = [task.inputs[key] for key in sample_fields if key in task.inputs]
             if len(matches) == 0:
-                print(f"Task {task.name} has no sample name-like field, skipping")
-                continue
+                if "output_basename" in task.inputs:
+                    # try parsing output_basename for sample name
+                    # this assumes out basenames are named like {sample_name}_taskid
+                    if isinstance(task.inputs["output_basename"], str):
+                        # skip if output_basename is not a string (mostly NGS checkmate)
+                        base_split = task.inputs["output_basename"].split("_")
+                        sample_name = "_".join(base_split[:2])
+                if sample_name is None:
+                    # if we can't figure out what the sample_name should be, skip this task
+                    print(f"Task {task.name} has no sample name-like field, skipping")
+                    continue
             elif len(matches) != 1:
                 raise ValueError(f"Expected exactly one match, got {len(matches)}")
-            sample_name = matches[0]
+            else:
+                sample_name = matches[0]
 
             # look up that sample name in the manifest
             metadata_row = man_df.loc[man_df["Bioassay_ID"] == sample_name].copy()

--- a/scripts/add_metatdata.py
+++ b/scripts/add_metatdata.py
@@ -94,6 +94,7 @@ def add_metadata(profile, project, task_file, manifest, output_file, debug):
         "reference_genome",
         "mean_coverage",
         "project",
+        "adapter_sequencing",
     ]
     man_df = man_df.drop(unneeded_cols, errors='ignore', axis=1).drop_duplicates()
 

--- a/scripts/add_metatdata.py
+++ b/scripts/add_metatdata.py
@@ -93,7 +93,7 @@ def add_metadata(profile, project, task_file, manifest, output_file, debug):
         "mean_coverage",
         "project",
     ]
-    man_df = man_df.drop(unneeded_cols, axis=1).drop_duplicates()
+    man_df = man_df.drop(unneeded_cols, errors='ignore', axis=1).drop_duplicates()
 
     if debug:
         print(man_df.columns)

--- a/scripts/add_metatdata.py
+++ b/scripts/add_metatdata.py
@@ -136,6 +136,7 @@ def add_metadata(profile, project, task_file, manifest, output_file, debug):
             metadata_row = man_df.loc[man_df["Bioassay_ID"] == sample_name].copy()
 
             if metadata_row.shape[0] > 1:
+                metadata_row.to_csv(f"{sample_name}_matches.tsv", sep="\t", index=False)
                 raise ValueError(f"{sample_name} has multiple values in {manifest}")
 
             task_df = pd.DataFrame(columns=["id", "name", "project"])

--- a/scripts/copy_files.py
+++ b/scripts/copy_files.py
@@ -34,10 +34,18 @@ def copy_files(file_ids, profile, project):
             files.append(line.strip())
 
     print(f"Copying files to project: {project}")
-    copy_results = api.actions.bulk_copy_files(
-        files=files,
-        destination_project=project,
-    )
+
+    # do copies in chunks of 500
+    chunk_size = 500
+    copy_results = {}
+    for i in range(0, len(files), chunk_size):
+        chunk = files[i : i + chunk_size]
+        print(f"Copying files {i} to {i + chunk_size}")
+        copy_result = api.actions.bulk_copy_files(
+            files=chunk,
+            destination_project=project,
+        )
+        copy_results.update(copy_result)
 
     for original_file_id, copy_result in copy_results.items():
         print(original_file_id, copy_result)


### PR DESCRIPTION
Quick bugfix I found. We didn't test any of the metadata updates on RNA samples.

This PR also updates the script to try to use `output_basename` if the task doesn't have a sample_name like field. This will cover pathogenicity preprocessing tasks.