### PR TITLE
Feature/as/export folders

### DIFF
--- a/README.md
+++ b/README.md
@@ -245,6 +245,10 @@ There are at least three ways to get file ids from Cavatica.
 
 The `export_file_by_id.py` script will export files from Cavatica. Authentication with AWS is handled through Cavatica, so you won't need any additional configuration.
 
+The input file, provided by the `file_ids` option is a tsv file with two required columns: `file_name` and `file_id`.
+
+Files can be exported to sub-prefixes within the bucket and prefix designated by the `volume` and `location` option, but this must be set manually in the input file. If the file_name contains `/`s, each slash will be a separate sub-prefix of the `location` option. For example, for the line `outputs/bob.txt 12345`, volume `--volume sicklera/my_test_volume`, and location `--location harmonized`; the file `bob.txt` will be exported to `harmonized/outputs/bob.txt` in the AWS bucket that `my_test_volume` corresponds to. If there are no `/`s in the file name, the file(s) will be exported to the prefix given by the `location` paramter.
+
 ** WARNING ** before running any export commands, have the command be reviewed by someone else to ensure the data are being exported to the correct bucket.
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -247,7 +247,7 @@ The `export_file_by_id.py` script will export files from Cavatica. Authenticatio
 
 The input file, provided by the `file_ids` option is a tsv file with two required columns: `file_name` and `file_id`.
 
-Files can be exported to sub-prefixes within the bucket and prefix designated by the `volume` and `location` option, but this must be set manually in the input file. If the file_name contains `/`s, each slash will be a separate sub-prefix of the `location` option. For example, for the line `outputs/bob.txt 12345`, volume `--volume sicklera/my_test_volume`, and location `--location harmonized`; the file `bob.txt` will be exported to `harmonized/outputs/bob.txt` in the AWS bucket that `my_test_volume` corresponds to. If there are no `/`s in the file name, the file(s) will be exported to the prefix given by the `location` paramter.
+Files can be exported to sub-prefixes within the bucket and prefix designated by the `volume` and `location` option. If the file_name contains `/`s, each slash will be a separate sub-prefix of the `location` option. For example, for the line `outputs/bob.txt 12345`, volume `--volume sicklera/my_test_volume`, and location `--location harmonized`; the file `bob.txt` will be exported to `harmonized/outputs/bob.txt` in the AWS bucket that `my_test_volume` corresponds to. If there are no `/`s in the file name, the file(s) will be exported to the prefix given by the `location` paramter.
 
 ** WARNING ** before running any export commands, have the command be reviewed by someone else to ensure the data are being exported to the correct bucket.
 

--- a/scripts/export_file_by_id.py
+++ b/scripts/export_file_by_id.py
@@ -127,7 +127,7 @@ def export_file_ids(file_ids, profile, volume, location, run):
                 )
                 for response in responses:
                     print(response)
-                print("fSuccessfully exported {len(file_location_dict[loc])} files to {volume}/{loc}")
+                print(f"Successfully exported {len(file_location_dict[loc])} files to {volume}/{loc}")
             else:
                 print("Dry run, not exporting")
                 print(f"Would export {len(file_location_dict[loc])} files to {volume}/{loc}")

--- a/scripts/export_file_by_id.py
+++ b/scripts/export_file_by_id.py
@@ -83,6 +83,8 @@ def export_file_ids(file_ids, profile, volume, location, run):
                 file_path = "/".join(file_split[:-1])
                 if file_path == "":
                     file_path = location
+                else:
+                    file_path = f"{location}/{file_path}"
                 try:
                     if file_path not in file_location_dict:
                         file_location_dict[file_path] = []

--- a/scripts/export_file_by_id.py
+++ b/scripts/export_file_by_id.py
@@ -94,6 +94,7 @@ def export_file_ids(file_ids, profile, volume, location, run):
     # loop through files and add any secondary files
     exportable_files = []
     for loc in file_location_dict:
+        unique_files = []
         for file in file_location_dict[loc]:
 
             # check that the file is exportable
@@ -105,9 +106,12 @@ def export_file_ids(file_ids, profile, volume, location, run):
                     if check_exportable(secondary):
                         files_to_export += 1
                         file_location_dict[loc].append(secondary)
-        file_location_dict[loc] = list(set(file_location_dict[loc]))
 
-    if len(files_to_export) > 0:
+            if file not in unique_files:
+                unique_files.append(file)
+        file_location_dict[loc] = unique_files
+
+    if files_to_export > 0:
         print(f"Exporting {len(exportable_files)} files to {volume}")
         # export files to each location
         for loc in file_location_dict:

--- a/scripts/export_file_by_id.py
+++ b/scripts/export_file_by_id.py
@@ -19,7 +19,6 @@ def check_exportable(file):
 
     Returns: boolean
     """
-
     exportable = True
 
     # check if there's files that start with _#
@@ -56,8 +55,7 @@ def check_exportable(file):
     required=True,
 )
 @click.option("--run", help="Run the export job", is_flag=True, default=False)
-@click.option("--debug", help="Print some debug messages", is_flag=True, default=False)
-def export_file_ids(file_ids, profile, volume, location, run, debug):
+def export_file_ids(file_ids, profile, volume, location, run):
     """
     Take a task or a list of tasks and export the output data
     to an AWS bucket.
@@ -65,71 +63,74 @@ def export_file_ids(file_ids, profile, volume, location, run, debug):
     """
     # read config file
     api = hf.parse_config(profile)
-    files_to_export = []
+    files_to_export = 0
     print(f"Getting file ids from file: {file_ids}")
     file_id_index = None
+    file_name_index = None
+    file_location_dict = {}
     with open(file_ids, "r") as f:
         for line in f:
             line_split = line.strip().split("\t")
             if "file_id" in line_split:
                 # get the index of the file_id column
                 file_id_index = line_split.index("file_id")
+                file_name_index = line_split.index("file_name")
             else:
                 file_id = line_split[file_id_index]
+                file_name = line_split[file_name_index]
+                file_split = file_name.split("/")
+                file_base_name = file_split[-1]
+                file_path = "/".join(file_split[:-1])
+                if file_path == "":
+                    file_path = location
                 try:
-                    files_to_export.append(api.files.get(id=file_id))
+                    if file_path not in file_location_dict:
+                        file_location_dict[file_path] = []
+                    file_location_dict[file_path].append(api.files.get(file_id))
+                    files_to_export += 1
                 except Exception as e:
                     print(f"Could not find file {file_id}: {e}")
 
-    if debug:
-        print(f"{len(files_to_export)} files to export")
-
     # loop through files and add any secondary files
     exportable_files = []
-    for file in files_to_export:
+    for loc in file_location_dict:
+        for file in file_location_dict[loc]:
 
-        # check that the file is exportable
-        if check_exportable(file):
-            exportable_files.append(file)
+            # check that the file is exportable
+            if check_exportable(file):
+                exportable_files.append(file)
 
-        if file.secondary_files is not None:
-            for secondary in file.secondary_files:
-                if check_exportable(secondary):
-                    exportable_files.append(secondary)
-
-    # remove duplicates
-    seen = set()
-    unique_files = []
-    for file in exportable_files:
-        if file.id not in seen:
-            unique_files.append(file)
-            seen.add(file.name)
-
-    exportable_files = unique_files
-
-    if debug:
-        print(f"Preparing to export the following files:")
-        for file in exportable_files:
-            print(f"{file.name}: {file.id}")
+            if file.secondary_files is not None:
+                for secondary in file.secondary_files:
+                    if check_exportable(secondary):
+                        files_to_export += 1
+                        file_location_dict[loc].append(secondary)
+        file_location_dict[loc] = list(set(file_location_dict[loc]))
 
     if len(files_to_export) > 0:
-        print(f"Exporting {len(exportable_files)} files to {volume}/{location}")
-        if run and not debug:
-            print("Running export")
-            responses = hf.bulk_export_files(
-                api=api,
-                files=exportable_files,
-                volume=volume,
-                location=location,
-                copy_only=False,
-            )
-            for response in responses:
-                print(response)
-            print("Export complete")
-        else:
-            print("Dry run, not exporting")
+        print(f"Exporting {len(exportable_files)} files to {volume}")
+        # export files to each location
+        for loc in file_location_dict:
+            print(f"Exporting {len(file_location_dict[loc])} files to {volume}/{loc}")
+            if run:
+                print("Running export")
+                responses = hf.bulk_export_files(
+                    api=api,
+                    files=file_location_dict[loc],
+                    volume=volume,
+                    location=loc,
+                    copy_only=False,
+                )
+                for response in responses:
+                    print(response)
+                print("fSuccessfully exported {len(file_location_dict[loc])} files to {volume}/{loc}")
+            else:
+                print("Dry run, not exporting")
+                print(f"Would export {len(file_location_dict[loc])} files to {volume}/{loc}")
+                print(f"Files: {[f.name for f in file_location_dict[loc]]}")
     else:
         print("No files to export")
+    print("Done!")
 
 
 if __name__ == "__main__":

--- a/scripts/get_files_by_task.py
+++ b/scripts/get_files_by_task.py
@@ -21,31 +21,33 @@ def get_regular_files(api, all_tasks, debug=False):
     """
     for task in all_tasks:
         files_to_display = []
-        files_to_display = check_and_get_files(task)
+        initial_files = []
+        initial_files = check_and_get_files(task)
 
         if debug:
             print(f"Current task id: {task.id}  {task.name}")
 
         # loop through files and add any secondary files, and check that both files exist
-        for file in files_to_display:
+        for file in initial_files:
             try:
                 file_obj = api.files.get(id=file)
             except NotFound as e:
                 print(f"Can't find {file}, file doesn't exist", file=sys.stderr)
 
             if file_obj.is_folder():
-                raise ValueError(
-                    f"{file_obj.name} is a folder. If you are getting files from an scRNA task, \
-                    use the --scrna option, if not this script cannot be used."
-                )
-                """
-                files_to_display.extend(hf.get_all_files_folder(api, file_obj))
-                files_to_display.remove(file)
-                # just print these to see what's going on
-                for f in files_to_display:
-                    print(f"{f.name}\t{f.id}\t{f.is_folder()}")
-                exit()
-                """
+                sub_files = hf.get_all_files_folder(api, file_obj)
+                for f in sub_files:
+                    if f.parent:
+                        parent = api.files.get(id=f.parent)
+                        f.name = f"{parent.name}/{f.name}"
+                        while parent.parent:
+                            parent = api.files.get(id=parent.parent)
+                            if parent.parent is not None:
+                                f.name = f"{parent.name}/{f.name}"
+                    if not f.is_folder():
+                        files_to_display.append(f)
+            else:
+                files_to_display.append(file)
 
             if file_obj.secondary_files is not None:
                 for secondary in file.secondary_files:

--- a/scripts/get_files_by_task.py
+++ b/scripts/get_files_by_task.py
@@ -10,6 +10,117 @@ from helper_functions import helper_functions as hf
 CONTEXT_SETTINGS = dict(help_option_names=["-h", "--help"])
 
 
+def get_regular_files(api, all_tasks, debug=False):
+    """
+    Get the file ids of output files from a list of tasks.
+    Inputs:
+    - api object
+    - list of task objects
+    Returns:
+    - list of file objects
+    """
+    for task in all_tasks:
+        files_to_display = []
+        files_to_display = check_and_get_files(task)
+
+        if debug:
+            print(f"Current task id: {task.id}  {task.name}")
+
+        # loop through files and add any secondary files, and check that both files exist
+        for file in files_to_display:
+            try:
+                file_obj = api.files.get(id=file)
+            except NotFound as e:
+                print(f"Can't find {file}, file doesn't exist", file=sys.stderr)
+
+            if file_obj.is_folder():
+                raise ValueError(
+                    f"{file_obj.name} is a folder. If you are getting files from an scRNA task, \
+                    use the --scrna option, if not this script cannot be used."
+                )
+                """
+                files_to_display.extend(hf.get_all_files_folder(api, file_obj))
+                files_to_display.remove(file)
+                # just print these to see what's going on
+                for f in files_to_display:
+                    print(f"{f.name}\t{f.id}\t{f.is_folder()}")
+                exit()
+                """
+
+            if file_obj.secondary_files is not None:
+                for secondary in file.secondary_files:
+                    try:
+                        file_obj = api.files.get(id=secondary)
+                    except NotFound as e:
+                        print(
+                            f"Can't find {file_obj.name}, file doesn't exist",
+                            file=sys.stderr,
+                        )
+                    # check if secondary already in list
+                    if secondary not in files_to_display:
+                        files_to_display.append(secondary)
+
+    return files_to_display
+
+
+def get_scrna_files(api, all_tasks, debug=False):
+    """
+    Get the file ids of output files from a list of scRNA tasks.
+    For scRNA tasks, the output file is just a folder.
+    Go through that folder, look for the results folder,
+    get all of the fiels in subfolders of the results folder.
+    Inputs:
+    - api object
+    - list of task objects
+    Returns:
+    - list of file objects
+    """
+    limit = hf.LIMIT if hasattr(hf, "LIMIT") else 50
+    display_files = []
+
+    for task in all_tasks:
+        if debug:
+            print(f"Current task id: {task.id}  {task.name}")
+
+        root_files = check_and_get_files(task)
+        if len(root_files) > 1:
+            raise ValueError("More than one output file found, task is not scrna.")
+
+        try:
+            file_obj = api.files.get(id=root_files[0])
+        except NotFound:
+            print(f"Can't find {root_files[0]}, file doesn't exist", file=sys.stderr)
+            continue
+        if not file_obj.is_folder():
+            raise ValueError(
+                f"{file_obj.name} is not a folder. If you are getting files from a non-scRNA task, \
+                do not use the --scrna option."
+            )
+        
+        # this folder will have results and checkpoints
+        sub_folders = hf.get_all_files_folder(api, file_obj)
+        results_folder = None
+        for fol in sub_folders:
+            if fol.name == "results":
+                results_folder = fol
+        if not results_folder:
+            print(f"ERROR: No results folder found in {file_obj.name}", file=sys.stderr)
+            exit(1)
+
+        # get all folder in results_folder
+        display_files = hf.get_all_files_folder(api, results_folder)
+
+    # remove folders from display_files
+    final_files = []
+    for d in display_files:
+        if not d.is_folder():
+            if debug:
+                print(f"Adding {d.name}")
+            final_files.append(d)
+
+    return final_files
+
+
 def check_and_get_files(task):
     """
     Check that a task is COMPLETED and get files.
@@ -38,7 +149,10 @@ def check_and_get_files(task):
                     files.append(task.outputs[out_key])
 
     elif task.status == "DRAFT":
-        print(f"{task.name} is a draft task and has not run yet, skipping", file=sys.stderr)
+        print(
+            f"{task.name} is a draft task and has not run yet, skipping",
+            file=sys.stderr,
+        )
     elif task.status == "RUNNING":
         print(f"{task.name} is currently running, skipping", file=sys.stderr)
     elif task.status == "FAILED":
@@ -60,7 +174,13 @@ def check_and_get_files(task):
     show_default=True,
 )
 @click.option("--debug", help="Print some debug messages", is_flag=True, default=False)
-def get_task_files(task_file, task_id, profile, debug):
+@click.option(
+    "--scrna",
+    help="If the task is an scRNA task, use this option to get the files",
+    is_flag=True,
+    default=False,
+)
+def get_task_files(task_file, task_id, profile, debug, scrna):
     """
     Take a task or a list of tasks and find all output files.
     """
@@ -80,37 +200,19 @@ def get_task_files(task_file, task_id, profile, debug):
                 task_id = line.strip()
                 all_tasks.append(api.tasks.get(id=task_id))
 
+    files_to_display = []
+    if scrna:
+        files_to_display = get_scrna_files(api, all_tasks, debug)
+    else:
+        files_to_display = get_regular_files(api, all_tasks, debug)
+
     print(f"file_name\tfile_id")
-    for task in all_tasks:
-        files_to_display = []
-        files_to_display = check_and_get_files(task)
-
-        if debug:
-            print(f"Current task id: {task.id}  {task.name}")
-
-        # loop through files and add any secondary files, and check that both files exist
+    if len(files_to_display) > 0:
+        # format output
         for file in files_to_display:
-            try:
-                file_obj = api.files.get(id=file)
-            except NotFound as e:
-                print(f"Can't find {file}, file doesn't exist", file=sys.stderr)
-
-            if file.secondary_files is not None:
-                for secondary in file.secondary_files:
-                    try:
-                        file_obj = api.files.get(id=secondary)
-                    except NotFound as e:
-                        print(f"Can't find {file.name}, file doesn't exist", file=sys.stderr)
-                    # check if secondary already in list
-                    if secondary not in files_to_display:
-                        files_to_display.append(secondary)
-
-        if len(files_to_display) > 0:
-            # format output
-            for file in files_to_display:
-                print(f"{file.name}\t{file.id}")
-        else:
-            print("No files found in input task(s)")
+            print(f"{file.name}\t{file.id}")
+    else:
+        print("No files found in input task(s)")
 
 
 if __name__ == "__main__":

--- a/scripts/helper_functions/helper_functions.py
+++ b/scripts/helper_functions/helper_functions.py
@@ -9,6 +9,43 @@ from sevenbridges.http.error_handlers import rate_limit_sleeper, maintenance_sle
 LIMIT = 50
 
 
+def get_all_files_folder(api, folder) -> list:
+    """
+    Get all files in a folder including in sub folders
+    Inputs:
+    - api: api obejct
+    - folder: file object with is_folder() == True
+    Returns:
+    - list of file objects in the folder and subfolders
+    """
+
+    all_files = []
+
+    if folder.is_folder() == False:
+        raise ValueError(f"ERROR: File {folder.name} is not a folder")
+    
+    # get all of the files in a folder
+    all_files.extend(folder.list_files(limit=LIMIT))
+    keep_going = True
+    while keep_going:
+        folder_files = folder.list_files(limit=LIMIT, offset=len(all_files))
+        all_files.extend(folder_files)
+        if len(all_files) >= folder_files.total:
+            keep_going = False
+
+    # check if any of the files are a folder
+    for file in all_files:
+        if file.is_folder() == True:
+            recieved = LIMIT
+            folder_files = file.list_files(limit=LIMIT)
+            all_files.extend(folder_files)
+            while recieved < folder_files.total:
+                folder_files = file.list_files(limit=LIMIT, offset=recieved)
+                recieved += LIMIT
+
+    return all_files
+
+
 def get_all_files(api, project) -> list:
     """
     Get all files in a project including in folders


### PR DESCRIPTION
Closes: #117

Now we can get the files that we want to export from the scRNA workflow. This isn't quite as generalized as I wanted it to be, but we can now export scRNA results. Just noting, for scRNA, we will need to go and cleanup the other files we don't want, mainly the ones in the `checkpoints` folders. This PR also fixes a bug where I wasn't using the file object when looking for secondary files.