### PR TITLE
:arrow_up: update checkout and add issue action steps to use node.js 24

### DIFF
--- a/.github/workflows/add-issues-to-project.yml
+++ b/.github/workflows/add-issues-to-project.yml
@@ -13,7 +13,7 @@ jobs:
     name: Add issue to project
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/add-to-project@244f685bbc3b7adfa8466e08b698b5577571133e
+      - uses: actions/add-to-project@5afcf98fcd03f1c2f92c3c83f58ae24323cc57fd
         with:
           # You can target a project in a different organization or user account
           # to the issue.

--- a/.github/workflows/make-cavatica-project.yml
+++ b/.github/workflows/make-cavatica-project.yml
@@ -16,7 +16,7 @@ jobs:
 
     steps:
       - name: Checkout API Repo
-        uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
         with:
           token: ${{ secrets.MY_REPO_PAT }}
       - name: Set up Python ${{ matrix.python-version }}


### PR DESCRIPTION
This PR updates two external actions that we're using to use Node.js 24 since 20 is deprecated and will stop working soon.

After this PR is approved and merged, I'll make sure it's working and then carry this update over to our other repos.

For more info: https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/