### PR TITLE
Feature/as/add app proj create update

### DIFF
--- a/.github/workflows/make-cavatica-project.yml
+++ b/.github/workflows/make-cavatica-project.yml
@@ -37,4 +37,10 @@ jobs:
         run: |
           python scripts/create_project.py \
           --token ${{ secrets.CAVATICA_TOKEN }} \
-          --run 
+          --run
+      - name: Close Issue
+        env:
+          GH_TOKEN: ${{ secrets.MY_REPO_PAT }}
+          ISSUE_NUMBER: ${{ github.event.issue.number }}
+        run: |
+          gh issue close "$ISSUE_NUMBER" --comment "Deployment finished. Issue closed automatically by CI/CD."

--- a/scripts/create_task_from_wf_cwl.py
+++ b/scripts/create_task_from_wf_cwl.py
@@ -152,7 +152,7 @@ def create_task_script(profile, app, workflow_file, out, skip_name_check, option
     task_ids = []
     file_ids = {}
     out_lines = []
-    new_cols = ["task_id", "created_by"]
+    new_cols = ["app", "task_id", "created_by"]
     base_names = {}
     with open(options_file, "r") as f:
         line_num = 0
@@ -255,7 +255,7 @@ def create_task_script(profile, app, workflow_file, out, skip_name_check, option
                 print(f"{new_task.name}, {new_task.status}, {new_task.id}")
                 task_ids.append(new_task.id)
                 out_lines.append(
-                    f"{line.strip()}\t{new_task.id}\t{username}\t{"\t".join([base_names[opt]["value"] for opt in base_names])}"
+                    f"{line.strip()}\t{new_task.app}\t{new_task.id}\t{username}\t{"\t".join([base_names[opt]["value"] for opt in base_names])}"
                 )
 
             line_num += 1

--- a/scripts/helper_functions/helper_functions.py
+++ b/scripts/helper_functions/helper_functions.py
@@ -6,7 +6,7 @@ from sevenbridges import Api
 from sevenbridges.http.error_handlers import rate_limit_sleeper, maintenance_sleeper
 
 # set api limit for pagination
-LIMIT = 50
+LIMIT = 100
 
 
 def get_all_files_folder(api, folder) -> list:


### PR DESCRIPTION
This PR:
- increases the pagination limit for api queries (really niche use but should speed things up)
- adds app id to the output file created by the create tasks script
- tries to close project creation issues after the project gets created

Closes: https://github.com/childrens-bti/cavatica_api_wrappers/issues/66