### PR TITLE
use built in github token

### DIFF
--- a/.github/workflows/make-cavatica-project.yml
+++ b/.github/workflows/make-cavatica-project.yml
@@ -9,6 +9,9 @@ jobs:
   create_cavatica_project:
     runs-on: ubuntu-latest
     environment: cavatica-prod
+    permissions:
+      contents: read
+      issues: write
     strategy:
       matrix:
         python-version: ['3.12.9']
@@ -17,8 +20,6 @@ jobs:
     steps:
       - name: Checkout API Repo
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
-        with:
-          token: ${{ secrets.MY_REPO_PAT }}
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065
         with:
@@ -40,7 +41,7 @@ jobs:
           --run
       - name: Close Issue
         env:
-          GH_TOKEN: ${{ secrets.MY_REPO_PAT }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           ISSUE_NUMBER: ${{ github.event.issue.number }}
         run: |
           gh issue close "$ISSUE_NUMBER" --comment "Deployment finished. Issue closed automatically by CI/CD."


### PR DESCRIPTION
Closes: #159 

For context, I updated the project creation action to comment on and close the issue, but the PAT I was using didn't have permission to write to issues (comment and close). From reading more documentation, I don't need the token because actions create their own one time use token.

https://docs.github.com/en/actions/tutorials/authenticate-with-github_token