### PR TITLE
Add cavatica task creation support support for tirtl-seq json inputs

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ python scripts/create_task_from_wf_cwl.py \
   --out aph17
 ```
 
-The script creates a draft task and then updates its output basename to `<Bioassay_ID>_<CAVATICA_TASK_ID>`. It writes the task ID to `aph17_task_ids.txt` and a credential-free audit record to `aph17_tasks.tsv`. The full input JSON is not copied because it may contain a MiXCR license.
+The script creates a draft task and then updates its output basename to `<Bioassay_ID>_<CAVATICA_TASK_ID>`. It writes the task ID to `aph17_task_ids.txt` and a credential-free task record to `aph17_options.tsv`, matching the existing TSV-mode output convention. The full input JSON is not copied because it may contain a MiXCR license.
 
 Inspect the draft in CAVATICA before launching it. To launch it with the wrapper:
 

--- a/README.md
+++ b/README.md
@@ -41,14 +41,14 @@ The $HOME/.sevenbridges/credentials file has a simple .ini file format, for exam
 
 ## Creating tasks from CWL workflows
 
-The `create_task_from_wf_cwl.py` script parses a Cavatica app and a tsv file with workflow inputs and app id and creates tasks runing the parsed workflow in a project. The input file is described below. When the script is run, it will create draft tasks at the endpoint provided by your profile and will create two output files. One containing the task ids of the created draft tasks and another with the options file with added columns: task_id, created_by, and updated output basenames appended with task ids. One task will be created for each line in the workflow inputs file. However, it won't load the workflow or any data needed to the project. This must be done separately.
+The `create_task_from_wf_cwl.py` script creates draft tasks from either a TSV options file containing a CAVATICA app ID or one structured task-input JSON file. One task is created for each TSV row; JSON mode creates one task from the supplied object. The script does not upload the workflow or input data to the project, so those must be prepared separately.
 
 ### Generating Tasks
 
 1. Create the project the workflow will be run in
 1. Add the workflow to the project
 1. Copy any reference and data files into the project
-1. Add inputs to the input tsv file
+1. Prepare a TSV options file or structured task-input JSON
 1. Run the script
 
 ### Script usage
@@ -58,13 +58,15 @@ To get a full list of inputs, run:
 python scripts/create_task_from_wf_cwl.py -h
 Usage: create_task_from_wf_cwl.py [OPTIONS]
 
-  Create a draft task from a workflow cwl and file with task options.
+  Create draft tasks from TSV options or one structured JSON input object.
 
 Options:
   --profile TEXT            Profile to use from credentials file  [default:
                             cavatica]
-  --out TEXT                Output file
+  --out TEXT                Output files basename
   --options_file PATH       Path to options file
+  --app TEXT                CAVATICA app ID; required with --task-inputs-json
+  --task-inputs-json FILE   JSON object containing inputs for one CAVATICA task
   -h, --help                Show this message and exit.
 ```
 
@@ -79,6 +81,29 @@ $ cat override.txt
 vcf_file    output_basename app
 BS_1234.vcf BS_1234_example_workflow_run  childrens-bti/dev/parse_vcf/0
 BS_9876.vcf BS_9876_example_workflow_run  childrens-bti/dev/parse_vcf/0
+```
+
+#### Structured JSON inputs (TIRTL-seq)
+
+Use `--task-inputs-json` when an upstream workflow helper has already generated structured CAVATICA inputs. The JSON must contain one object with a non-empty string `output_basename`. For TIRTL-seq, this value is the plate's `Bioassay_ID`.
+
+```bash
+python scripts/create_task_from_wf_cwl.py \
+  --profile cavatica \
+  --app childrens-bti/tirtl-dev/tirtl-cwl/13 \
+  --task-inputs-json /path/to/aph17_cavatica_inputs.json \
+  --out aph17
+```
+
+The script creates a draft task and then updates its output basename to `<Bioassay_ID>_<CAVATICA_TASK_ID>`. It writes the task ID to `aph17_task_ids.txt` and a credential-free audit record to `aph17_tasks.tsv`. The full input JSON is not copied because it may contain a MiXCR license.
+
+Inspect the draft in CAVATICA before launching it. To launch it with the wrapper:
+
+```bash
+python scripts/run_tasks.py \
+  --profile cavatica \
+  --task_file aph17_task_ids.txt \
+  --output_basename aph17
 ```
 
 ## Launching draft tasks

--- a/scripts/create_task_from_wf_cwl.py
+++ b/scripts/create_task_from_wf_cwl.py
@@ -1,6 +1,8 @@
 """Create a draft task from a workflow cwl"""
 
 import click
+import csv
+import json
 import sys
 import datetime
 import time
@@ -38,6 +40,93 @@ def wrap_file_obj(api, project, cur_input):
             ) from exc
 
     return hf.get_file_obj(api, project, cur_input)
+
+
+def parse_app_id(app):
+    """Return the project and app name from an app ID, with an optional revision."""
+    parts = app.strip("/").split("/")
+    if len(parts) not in (3, 4) or not all(parts):
+        raise click.UsageError(
+            "--app must use the format user/project/app or user/project/app/revision"
+        )
+    return "/".join(parts[:2]), parts[2]
+
+
+def load_task_inputs_json(path):
+    """Load and validate inputs for one JSON-backed task."""
+    try:
+        with open(path, "r") as handle:
+            task_inputs = json.load(handle)
+    except json.JSONDecodeError as exc:
+        raise click.ClickException(
+            f"Task inputs JSON is not valid JSON: {path}: {exc}"
+        ) from exc
+
+    if not isinstance(task_inputs, dict):
+        raise click.ClickException("Task inputs JSON must contain one JSON object")
+
+    output_basename = task_inputs.get("output_basename")
+    if not isinstance(output_basename, str) or not output_basename.strip():
+        raise click.ClickException(
+            "Task inputs JSON must contain a non-empty string output_basename"
+        )
+
+    output_basename = output_basename.strip()
+    task_inputs["output_basename"] = output_basename
+    return task_inputs, output_basename
+
+
+def create_task_from_json(
+    api,
+    username,
+    app,
+    project,
+    app_name,
+    task_inputs,
+    original_output_basename,
+    out,
+    today,
+):
+    """Create and record one draft task from structured JSON inputs."""
+    task_name = f"{app_name}_{today}_{original_output_basename}"
+    new_task = api.tasks.create(
+        name=task_name, project=project, app=app, inputs=task_inputs
+    )
+    final_output_basename = f"{original_output_basename}_{new_task.id}"
+
+    try:
+        new_task.inputs["output_basename"] = final_output_basename
+        new_task.save()
+    except Exception as exc:
+        raise click.ClickException(
+            f"Draft task {new_task.id} was created, but updating output_basename failed: {exc}"
+        ) from exc
+
+    print(f"{new_task.name}, {new_task.status}, {new_task.id}")
+
+    with open(f"{out}_task_ids.txt", "w") as handle:
+        handle.write(f"{new_task.id}\n")
+
+    with open(f"{out}_tasks.tsv", "w", newline="") as handle:
+        writer = csv.writer(handle, delimiter="\t", lineterminator="\n")
+        writer.writerow(
+            [
+                "app",
+                "task_id",
+                "created_by",
+                "original_output_basename",
+                "final_output_basename",
+            ]
+        )
+        writer.writerow(
+            [
+                app,
+                new_task.id,
+                username,
+                original_output_basename,
+                final_output_basename,
+            ]
+        )
 
 
 def get_input_type(my_input):
@@ -127,10 +216,34 @@ def parse_workflow_app(api, app):
     type=click.Path(exists=True),
     help="Path to options file",
 )
-def create_task_script(profile, out, options_file):
+@click.option(
+    "--app",
+    help="CAVATICA app ID; required with --task-inputs-json",
+)
+@click.option(
+    "--task-inputs-json",
+    type=click.Path(exists=True, dir_okay=False),
+    help="JSON object containing inputs for one CAVATICA task",
+)
+def create_task_script(profile, out, options_file, app, task_inputs_json):
     """
-    Create a draft task from a workflow cwl and file with task options.
+    Create draft tasks from TSV options or one structured JSON input object.
     """
+
+    if bool(options_file) == bool(task_inputs_json):
+        raise click.UsageError(
+            "Provide exactly one of --options_file or --task-inputs-json"
+        )
+    # Validate JSON before connecting to CAVATICA.
+    json_task_inputs = None
+    json_output_basename = None
+    if task_inputs_json:
+        if not app:
+            raise click.UsageError("--app is required with --task-inputs-json")
+        project_id, web_app_name = parse_app_id(app)
+        json_task_inputs, json_output_basename = load_task_inputs_json(
+            task_inputs_json
+        )
 
     today = datetime.datetime.now().strftime("%Y%m%d")
 
@@ -138,6 +251,20 @@ def create_task_script(profile, out, options_file):
     api = hf.parse_config(profile)
     username = api.users.me().username
 
+    if task_inputs_json:
+        project = hf.parse_project(project_id)
+        create_task_from_json(
+            api,
+            username,
+            app,
+            project,
+            web_app_name,
+            json_task_inputs,
+            json_output_basename,
+            out,
+            today,
+        )
+        return
     # parse options file and create tasks
     task_ids = []
     file_ids = {}

--- a/scripts/create_task_from_wf_cwl.py
+++ b/scripts/create_task_from_wf_cwl.py
@@ -107,7 +107,7 @@ def create_task_from_json(
     with open(f"{out}_task_ids.txt", "w") as handle:
         handle.write(f"{new_task.id}\n")
 
-    with open(f"{out}_tasks.tsv", "w", newline="") as handle:
+    with open(f"{out}_options.tsv", "w", newline="") as handle:
         writer = csv.writer(handle, delimiter="\t", lineterminator="\n")
         writer.writerow(
             [


### PR DESCRIPTION
<!--Hi there, thanks for your contribution! Please take a moment to fill out this template to facilitate the review of your pull request.-->

### Purpose/implementation Section

- Add --task-inputs-json for creating a TIRTL-seq draft task from structured CAVATICA inputs.
- Append the assigned CAVATICA task ID to the Bioassay-based output_basename.
- Support revisioned CAVATICA app IDs.
- Write a task-ID file and credential-free audit TSV.

- Successfully created an aph17 draft task in [`tirtl-dev` CAVATICA project ](https://cavatica.sbgenomics.com/u/childrens-bti/tirtl-dev/tasks/b5947012-4ce8-4d44-9936-6fae1e4cf415/#set-input-data)
- Confirmed the final basename uses aph17_<TASK_ID>. aph17 being the temporary placeholder for BAID. 
- Confirmed the task remained in DRAFT status.

#### What GitHub issue does your pull request address?



### Directions for reviewers. Tell potential reviewers what kind of feedback you are soliciting.

#### Which areas should receive a particularly close look?



#### Is there anything that you want to discuss further?



#### Is the analysis in a mature enough form that the resulting figure(s) and/or table(s) are ready for review?



### Results

#### What types of results are included (e.g., table, figure)?



#### What is your summary of the results?



#### Reproducibility Checklist

<!-- Check all those that apply or remove this section if it is not applicable.-->

- [X] The dependencies required to run the code in this pull request have been added to the project Dockerfile.

#### Documentation Checklist

- [X] This analysis module has a `README` and it is up to date.
- [X] The analytical code is documented and contains comments.
