### PR TITLE
Add cavatica task creation support support for tirtl-seq json inputs

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,17 +41,13 @@ The $HOME/.sevenbridges/credentials file has a simple .ini file format, for exam
 
 ## Creating tasks from CWL workflows
 
-Warning: this is very experimental and created tasks should be manually veririfed before using!
-
-The `create_task_from_wf_cwl.py` script parses a CWL workflow and a tsv file with workflow inputs and creates tasks runing the parsed workflow in a project. The input file is described below. When the script is run, it will create draft tasks at the endpoint provided by your profile and will output a file containing the task ids of the created draft tasks. One task will be created for each line in the workflow inputs file. However, it won't load the workflow or any data needed to the project. This must be done separately.
+The `create_task_from_wf_cwl.py` script parses a Cavatica app and a tsv file with workflow inputs and app id and creates tasks runing the parsed workflow in a project. The input file is described below. When the script is run, it will create draft tasks at the endpoint provided by your profile and will create two output files. One containing the task ids of the created draft tasks and another with the options file with added columns: task_id, created_by, and updated output basenames appended with task ids. One task will be created for each line in the workflow inputs file. However, it won't load the workflow or any data needed to the project. This must be done separately.
 
 ### Generating Tasks
 
 1. Create the project the workflow will be run in
 1. Add the workflow to the project
 1. Copy any reference and data files into the project
-1. Clone the repo with the input workflow
-1. Checkout the same github version of the workflow that matches the workflow in the project
 1. Add inputs to the input tsv file
 1. Run the script
 
@@ -67,26 +63,22 @@ Usage: create_task_from_wf_cwl.py [OPTIONS]
 Options:
   --profile TEXT            Profile to use from credentials file  [default:
                             cavatica]
-  --app TEXT                App name, appid field on Cavaita app page
-  -w, --workflow_file PATH  Path to workflow file
   --out TEXT                Output file
-  --skip_name_check         Skip checking if app name and workflow file name
-                            match
   --options_file PATH       Path to options file
   -h, --help                Show this message and exit.
 ```
 
 #### The Options File
 
-The options file is a tsv file with column names corresponding to workflow inputs. If an input is found in the options file, the values in that column will be used when creating draft tasks and will override any default or suggested values for that input. For example, if a workflow has an input `reference_fasta`, the values listed in the `reference_fasta` column in the input file will be used and the default value in the workflow will not.
+The options file is a tsv file with column names corresponding to workflow inputs. It also requires an "app" column which is the app id for the app found in Cavatica; app ids will be in the form "project_creator/project_name/app_name/(optionally revision #)". If an input is found in the options file, the values in that column will be used when creating draft tasks and will override any default or suggested values for that input. For example, if a workflow has an input `reference_fasta`, the values listed in the `reference_fasta` column in the input file will be used and the default value in the workflow will not.
 
 Example options file
 
 ```bash
 $ cat override.txt
-vcf_file    output_basename
-BS_1234.vcf BS_1234_example_workflow_run
-BS_9876.vcf BS_9876_example_workflow_run
+vcf_file    output_basename app
+BS_1234.vcf BS_1234_example_workflow_run  childrens-bti/dev/parse_vcf/0
+BS_9876.vcf BS_9876_example_workflow_run  childrens-bti/dev/parse_vcf/0
 ```
 
 ## Launching draft tasks

--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ python scripts/create_task_from_wf_cwl.py \
   --out aph17
 ```
 
-The script creates a draft task and then updates its output basename to `<Bioassay_ID>_<CAVATICA_TASK_ID>`. It writes the task ID to `aph17_task_ids.txt` and a credential-free audit record to `aph17_tasks.tsv`. The full input JSON is not copied because it may contain a MiXCR license.
+The script creates a draft task and then updates its output basename to `<Bioassay_ID>_<CAVATICA_TASK_ID>`. It writes the task ID to `aph17_task_ids.txt` and a credential-free task record to `aph17_options.tsv`, matching the existing TSV-mode output convention. The full input JSON is not copied because it may contain a MiXCR license.
 
 Inspect the draft in CAVATICA before launching it. To launch it with the wrapper:
 

--- a/README.md
+++ b/README.md
@@ -41,14 +41,14 @@ The $HOME/.sevenbridges/credentials file has a simple .ini file format, for exam
 
 ## Creating tasks from CWL workflows
 
-The `create_task_from_wf_cwl.py` script parses a Cavatica app and a tsv file with workflow inputs and app id and creates tasks runing the parsed workflow in a project. The input file is described below. When the script is run, it will create draft tasks at the endpoint provided by your profile and will create two output files. One containing the task ids of the created draft tasks and another with the options file with added columns: task_id, created_by, and updated output basenames appended with task ids. One task will be created for each line in the workflow inputs file. However, it won't load the workflow or any data needed to the project. This must be done separately.
+The `create_task_from_wf_cwl.py` script creates draft tasks from either a TSV options file containing a CAVATICA app ID or one structured task-input JSON file. One task is created for each TSV row; JSON mode creates one task from the supplied object. The script does not upload the workflow or input data to the project, so those must be prepared separately.
 
 ### Generating Tasks
 
 1. Create the project the workflow will be run in
 1. Add the workflow to the project
 1. Copy any reference and data files into the project
-1. Add inputs to the input tsv file
+1. Prepare a TSV options file or structured task-input JSON
 1. Run the script
 
 ### Script usage
@@ -58,13 +58,15 @@ To get a full list of inputs, run:
 python scripts/create_task_from_wf_cwl.py -h
 Usage: create_task_from_wf_cwl.py [OPTIONS]
 
-  Create a draft task from a workflow cwl and file with task options.
+  Create draft tasks from TSV options or one structured JSON input object.
 
 Options:
   --profile TEXT            Profile to use from credentials file  [default:
                             cavatica]
-  --out TEXT                Output file
+  --out TEXT                Output files basename
   --options_file PATH       Path to options file
+  --app TEXT                CAVATICA app ID; required with --task-inputs-json
+  --task-inputs-json FILE   JSON object containing inputs for one CAVATICA task
   -h, --help                Show this message and exit.
 ```
 
@@ -79,6 +81,29 @@ $ cat override.txt
 vcf_file    output_basename app
 BS_1234.vcf BS_1234_example_workflow_run  childrens-bti/dev/parse_vcf/0
 BS_9876.vcf BS_9876_example_workflow_run  childrens-bti/dev/parse_vcf/0
+```
+
+#### Structured JSON inputs (TIRTL-seq)
+
+Use `--task-inputs-json` when an upstream workflow helper has already generated structured CAVATICA inputs. The JSON must contain one object with a non-empty string `output_basename`. For TIRTL-seq, this value is the plate's `Bioassay_ID`.
+
+```bash
+python scripts/create_task_from_wf_cwl.py \
+  --profile cavatica \
+  --app childrens-bti/tirtl-dev/tirtl-cwl/13 \
+  --task-inputs-json /path/to/aph17_cavatica_inputs.json \
+  --out aph17
+```
+
+The script creates a draft task and then updates its output basename to `<Bioassay_ID>_<CAVATICA_TASK_ID>`. It writes the task ID to `aph17_task_ids.txt` and a credential-free audit record to `aph17_tasks.tsv`. The full input JSON is not copied because it may contain a MiXCR license.
+
+Inspect the draft in CAVATICA before launching it. To launch it with the wrapper:
+
+```bash
+python scripts/run_tasks.py \
+  --profile cavatica \
+  --task_file aph17_task_ids.txt \
+  --output_basename aph17
 ```
 
 ## Launching draft tasks

--- a/README.md
+++ b/README.md
@@ -84,17 +84,7 @@ BS_9876.vcf BS_9876_example_workflow_run  childrens-bti/dev/parse_vcf/0
 
 #### Structured JSON inputs (TIRTL-seq)
 
-Use `--task-inputs-json` when an upstream workflow helper has already generated structured CAVATICA inputs. The JSON must contain a non-empty `app` string identifying the CAVATICA app and a non-empty `output_basename`. For TIRTL-seq, `output_basename` is the plate's `Bioassay_ID`. The wrapper removes `app` before submitting the remaining values as workflow inputs.
-
-```json
-{
-  "app": "childrens-bti/tirtl-dev/tirtl-cwl/13",
-  "output_basename": "aph17",
-  "r1_files": [],
-  "r2_files": [],
-  "well_names": []
-}
-```
+Use `--task-inputs-json` when an upstream workflow helper has already generated structured CAVATICA inputs. The JSON must contain a non-empty `app` string identifying the CAVATICA app and a non-empty `output_basename`. For TIRTL-seq, `output_basename` is the plate's `Bioassay_ID`. The wrapper removes `app` before submitting the remaining values as workflow inputs. Like TSV mode, it rejects options not defined by the app and reports validation errors returned by CAVATICA with the draft task ID.
 
 ```bash
 python scripts/create_task_from_wf_cwl.py \

--- a/README.md
+++ b/README.md
@@ -65,7 +65,6 @@ Options:
                             cavatica]
   --out TEXT                Output files basename
   --options_file PATH       Path to options file
-  --app TEXT                CAVATICA app ID; required with --task-inputs-json
   --task-inputs-json FILE   JSON object containing inputs for one CAVATICA task
   -h, --help                Show this message and exit.
 ```
@@ -85,12 +84,21 @@ BS_9876.vcf BS_9876_example_workflow_run  childrens-bti/dev/parse_vcf/0
 
 #### Structured JSON inputs (TIRTL-seq)
 
-Use `--task-inputs-json` when an upstream workflow helper has already generated structured CAVATICA inputs. The JSON must contain one object with a non-empty string `output_basename`. For TIRTL-seq, this value is the plate's `Bioassay_ID`.
+Use `--task-inputs-json` when an upstream workflow helper has already generated structured CAVATICA inputs. The JSON must contain a non-empty `app` string identifying the CAVATICA app and a non-empty `output_basename`. For TIRTL-seq, `output_basename` is the plate's `Bioassay_ID`. The wrapper removes `app` before submitting the remaining values as workflow inputs.
+
+```json
+{
+  "app": "childrens-bti/tirtl-dev/tirtl-cwl/13",
+  "output_basename": "aph17",
+  "r1_files": [],
+  "r2_files": [],
+  "well_names": []
+}
+```
 
 ```bash
 python scripts/create_task_from_wf_cwl.py \
   --profile cavatica \
-  --app childrens-bti/tirtl-dev/tirtl-cwl/13 \
   --task-inputs-json /path/to/aph17_cavatica_inputs.json \
   --out aph17
 ```

--- a/scripts/copy_files.py
+++ b/scripts/copy_files.py
@@ -19,7 +19,21 @@ CONTEXT_SETTINGS = dict(help_option_names=["-h", "--help"])
     default="cavatica",
     show_default=True,
 )
-def copy_files(file_ids, profile, project):
+@click.option(
+    "--chunk_size",
+    help="Number of files to copy per bulk request",
+    default=100,
+    show_default=True,
+    type=int,
+)
+@click.option(
+    "--skip_existing",
+    help="Skip files that already exist by name in the destination project",
+    is_flag=True,
+    default=False,
+    show_default=True,
+)
+def copy_files(file_ids, profile, project, chunk_size, skip_existing):
     """
     Copy a list of file ids to a new target project.
     """
@@ -36,17 +50,40 @@ def copy_files(file_ids, profile, project):
 
     print(f"Copying files to project: {project}")
 
+    existing_names = None
+    if skip_existing:
+        existing_names = {f.name for f in hf.get_all_files(api, project) if not f.is_folder()}
+
     # do copies in chunks
-    chunk_size = 100
     copy_results = {}
     with tqdm(total=len(files), desc="Copying files", unit="file") as progress:
         for i in range(0, len(files), chunk_size):
             chunk = files[i : i + chunk_size]
-            copy_result = api.actions.bulk_copy_files(
-                files=chunk,
-                destination_project=project,
-            )
-            copy_results.update(copy_result)
+
+            to_copy = chunk
+            if skip_existing:
+                # look up names for this chunk and skip files already in the project
+                records = api.files.bulk_get(files=chunk)
+                to_copy = []
+                for record in records:
+                    if record.resource.name in existing_names:
+                        progress.write(f"Skipping {record.resource.id} ({record.resource.name}), already exists in {project}")
+                    else:
+                        to_copy.append(record.resource.id)
+
+            if to_copy:
+                copy_result = api.actions.bulk_copy_files(
+                    files=to_copy,
+                    destination_project=project,
+                )
+                copy_results.update(copy_result)
+                if skip_existing:
+                    existing_names.update(
+                        record.resource.name
+                        for record in records
+                        if record.resource.id in to_copy
+                    )
+
             progress.update(len(chunk))
 
     for original_file_id, copy_result in copy_results.items():

--- a/scripts/create_task_from_wf_cwl.py
+++ b/scripts/create_task_from_wf_cwl.py
@@ -1,6 +1,8 @@
 """Create a draft task from a workflow cwl"""
 
 import click
+import csv
+import json
 import sys
 import datetime
 import time
@@ -42,6 +44,93 @@ def wrap_file_obj(api, project, cur_input):
             ) from exc
 
     return hf.get_file_obj(api, project, cur_input)
+
+
+def parse_app_id(app):
+    """Return the project and app name from an app ID, with an optional revision."""
+    parts = app.strip("/").split("/")
+    if len(parts) not in (3, 4) or not all(parts):
+        raise click.UsageError(
+            "--app must use the format user/project/app or user/project/app/revision"
+        )
+    return "/".join(parts[:2]), parts[2]
+
+
+def load_task_inputs_json(path):
+    """Load and validate inputs for one JSON-backed task."""
+    try:
+        with open(path, "r") as handle:
+            task_inputs = json.load(handle)
+    except json.JSONDecodeError as exc:
+        raise click.ClickException(
+            f"Task inputs JSON is not valid JSON: {path}: {exc}"
+        ) from exc
+
+    if not isinstance(task_inputs, dict):
+        raise click.ClickException("Task inputs JSON must contain one JSON object")
+
+    output_basename = task_inputs.get("output_basename")
+    if not isinstance(output_basename, str) or not output_basename.strip():
+        raise click.ClickException(
+            "Task inputs JSON must contain a non-empty string output_basename"
+        )
+
+    output_basename = output_basename.strip()
+    task_inputs["output_basename"] = output_basename
+    return task_inputs, output_basename
+
+
+def create_task_from_json(
+    api,
+    username,
+    app,
+    project,
+    app_name,
+    task_inputs,
+    original_output_basename,
+    out,
+    today,
+):
+    """Create and record one draft task from structured JSON inputs."""
+    task_name = f"{app_name}_{today}_{original_output_basename}"
+    new_task = api.tasks.create(
+        name=task_name, project=project, app=app, inputs=task_inputs
+    )
+    final_output_basename = f"{original_output_basename}_{new_task.id}"
+
+    try:
+        new_task.inputs["output_basename"] = final_output_basename
+        new_task.save()
+    except Exception as exc:
+        raise click.ClickException(
+            f"Draft task {new_task.id} was created, but updating output_basename failed: {exc}"
+        ) from exc
+
+    print(f"{new_task.name}, {new_task.status}, {new_task.id}")
+
+    with open(f"{out}_task_ids.txt", "w") as handle:
+        handle.write(f"{new_task.id}\n")
+
+    with open(f"{out}_tasks.tsv", "w", newline="") as handle:
+        writer = csv.writer(handle, delimiter="\t", lineterminator="\n")
+        writer.writerow(
+            [
+                "app",
+                "task_id",
+                "created_by",
+                "original_output_basename",
+                "final_output_basename",
+            ]
+        )
+        writer.writerow(
+            [
+                app,
+                new_task.id,
+                username,
+                original_output_basename,
+                final_output_basename,
+            ]
+        )
 
 
 def get_input_type(my_input):
@@ -131,10 +220,34 @@ def parse_workflow_app(api, app):
     type=click.Path(exists=True),
     help="Path to options file",
 )
-def create_task_script(profile, out, options_file):
+@click.option(
+    "--app",
+    help="CAVATICA app ID; required with --task-inputs-json",
+)
+@click.option(
+    "--task-inputs-json",
+    type=click.Path(exists=True, dir_okay=False),
+    help="JSON object containing inputs for one CAVATICA task",
+)
+def create_task_script(profile, out, options_file, app, task_inputs_json):
     """
-    Create a draft task from a workflow cwl and file with task options.
+    Create draft tasks from TSV options or one structured JSON input object.
     """
+
+    if bool(options_file) == bool(task_inputs_json):
+        raise click.UsageError(
+            "Provide exactly one of --options_file or --task-inputs-json"
+        )
+    # Validate JSON before connecting to CAVATICA.
+    json_task_inputs = None
+    json_output_basename = None
+    if task_inputs_json:
+        if not app:
+            raise click.UsageError("--app is required with --task-inputs-json")
+        project_id, web_app_name = parse_app_id(app)
+        json_task_inputs, json_output_basename = load_task_inputs_json(
+            task_inputs_json
+        )
 
     today = datetime.datetime.now().strftime("%Y%m%d")
 
@@ -142,6 +255,20 @@ def create_task_script(profile, out, options_file):
     api = hf.parse_config(profile)
     username = api.users.me().username
 
+    if task_inputs_json:
+        project = hf.parse_project(project_id)
+        create_task_from_json(
+            api,
+            username,
+            app,
+            project,
+            web_app_name,
+            json_task_inputs,
+            json_output_basename,
+            out,
+            today,
+        )
+        return
     # parse options file and create tasks
     task_ids = []
     file_ids = {}

--- a/scripts/create_task_from_wf_cwl.py
+++ b/scripts/create_task_from_wf_cwl.py
@@ -30,9 +30,13 @@ def wrap_file_obj(api, project, cur_input):
     suff = path.suffix
     if suff in my_indices:
         main_file = path.stem
-        print(f"Found index file {cur_input}, trying to get main file{main_file}")
+        print(f"Found index file {cur_input}, trying to get main file {main_file}")
         try:
-            return hf.get_file_obj(api, project, main_file)
+            # return hf.get_file_obj(api, project, main_file)
+            main_obj = hf.get_file_obj(api, project, main_file)
+            raise ValueError(
+                f"Index file given. Update options file to include {main_file} instead of {cur_input}"
+            )
         except FileNotFoundError as exc:
             raise ValueError(
                 f"Main file {main_file} for index {cur_input} was not found"

--- a/scripts/create_task_from_wf_cwl.py
+++ b/scripts/create_task_from_wf_cwl.py
@@ -1,6 +1,8 @@
 """Create a draft task from a workflow cwl"""
 
 import click
+import csv
+import json
 import sys
 import datetime
 import time
@@ -38,6 +40,93 @@ def wrap_file_obj(api, project, cur_input):
             ) from exc
 
     return hf.get_file_obj(api, project, cur_input)
+
+
+def parse_app_id(app):
+    """Return the project and app name from an app ID, with an optional revision."""
+    parts = app.strip("/").split("/")
+    if len(parts) not in (3, 4) or not all(parts):
+        raise click.UsageError(
+            "--app must use the format user/project/app or user/project/app/revision"
+        )
+    return "/".join(parts[:2]), parts[2]
+
+
+def load_task_inputs_json(path):
+    """Load and validate inputs for one JSON-backed task."""
+    try:
+        with open(path, "r") as handle:
+            task_inputs = json.load(handle)
+    except json.JSONDecodeError as exc:
+        raise click.ClickException(
+            f"Task inputs JSON is not valid JSON: {path}: {exc}"
+        ) from exc
+
+    if not isinstance(task_inputs, dict):
+        raise click.ClickException("Task inputs JSON must contain one JSON object")
+
+    output_basename = task_inputs.get("output_basename")
+    if not isinstance(output_basename, str) or not output_basename.strip():
+        raise click.ClickException(
+            "Task inputs JSON must contain a non-empty string output_basename"
+        )
+
+    output_basename = output_basename.strip()
+    task_inputs["output_basename"] = output_basename
+    return task_inputs, output_basename
+
+
+def create_task_from_json(
+    api,
+    username,
+    app,
+    project,
+    app_name,
+    task_inputs,
+    original_output_basename,
+    out,
+    today,
+):
+    """Create and record one draft task from structured JSON inputs."""
+    task_name = f"{app_name}_{today}_{original_output_basename}"
+    new_task = api.tasks.create(
+        name=task_name, project=project, app=app, inputs=task_inputs
+    )
+    final_output_basename = f"{original_output_basename}_{new_task.id}"
+
+    try:
+        new_task.inputs["output_basename"] = final_output_basename
+        new_task.save()
+    except Exception as exc:
+        raise click.ClickException(
+            f"Draft task {new_task.id} was created, but updating output_basename failed: {exc}"
+        ) from exc
+
+    print(f"{new_task.name}, {new_task.status}, {new_task.id}")
+
+    with open(f"{out}_task_ids.txt", "w") as handle:
+        handle.write(f"{new_task.id}\n")
+
+    with open(f"{out}_tasks.tsv", "w", newline="") as handle:
+        writer = csv.writer(handle, delimiter="\t", lineterminator="\n")
+        writer.writerow(
+            [
+                "app",
+                "task_id",
+                "created_by",
+                "original_output_basename",
+                "final_output_basename",
+            ]
+        )
+        writer.writerow(
+            [
+                app,
+                new_task.id,
+                username,
+                original_output_basename,
+                final_output_basename,
+            ]
+        )
 
 
 def get_input_type(my_input):
@@ -127,10 +216,34 @@ def parse_workflow_app(api, app):
     type=click.Path(exists=True),
     help="Path to options file",
 )
-def create_task_script(profile, out, options_file):
+@click.option(
+    "--app",
+    help="CAVATICA app ID; required with --task-inputs-json",
+)
+@click.option(
+    "--task-inputs-json",
+    type=click.Path(exists=True, dir_okay=False),
+    help="JSON object containing inputs for one CAVATICA task",
+)
+def create_task_script(profile, out, options_file, app, task_inputs_json):
     """
-    Create a draft task from a workflow cwl and file with task options.
+    Create draft tasks from TSV options or one structured JSON input object.
     """
+
+    if bool(options_file) == bool(task_inputs_json):
+        raise click.UsageError(
+            "Provide exactly one of --options_file or --task-inputs-json"
+        )
+    # Validate JSON before connecting to CAVATICA.
+    json_task_inputs = None
+    json_output_basename = None
+    if task_inputs_json:
+        if not app:
+            raise click.UsageError("--app is required with --task-inputs-json")
+        project_id, web_app_name = parse_app_id(app)
+        json_task_inputs, json_output_basename = load_task_inputs_json(
+            task_inputs_json
+        )
 
     today = datetime.datetime.now().strftime("%Y%m%d")
 
@@ -138,6 +251,20 @@ def create_task_script(profile, out, options_file):
     api = hf.parse_config(profile)
     username = api.users.me().username
 
+    if task_inputs_json:
+        project = hf.parse_project(project_id)
+        create_task_from_json(
+            api,
+            username,
+            app,
+            project,
+            web_app_name,
+            json_task_inputs,
+            json_output_basename,
+            out,
+            today,
+        )
+        return
     # parse options file and create tasks
     task_ids = []
     file_ids = {}

--- a/scripts/create_task_from_wf_cwl.py
+++ b/scripts/create_task_from_wf_cwl.py
@@ -2,7 +2,6 @@
 
 import click
 import sys
-import yaml
 import datetime
 import time
 from pathlib import Path
@@ -102,40 +101,19 @@ def get_input_type(my_input):
     return in_type, is_array
 
 
-def parse_workflow_file(workflow_file):
+def parse_workflow_app(api, app):
     """
-    Parse workflow file and return inputs
+    Parse workflow app and return inputs
     """
     workflow_inputs = {}
     array_inputs = []
-    with open(workflow_file, "r") as stream:
-        try:
-            workflow = yaml.safe_load(stream)
-            inputs = workflow["inputs"]
-            for input in inputs:
-                # figure out input type
-                # if inputs are a list, the input workflow is stricter yaml format
-                # likely exported from Cavatica
-                if isinstance(inputs, list):
-                    workflow_inputs[input["id"]], array_input = get_input_type(
-                        input["type"]
-                    )
-                    if array_input:
-                        array_inputs.append(input["id"])
-                elif isinstance(inputs[input], str):
-                    if "[]" in inputs[input]:
-                        array_inputs.append(input)
-                    workflow_inputs[input] = "string"
-                elif isinstance(inputs[input], dict):
-                    workflow_inputs[input], array_input = get_input_type(
-                        inputs[input]["type"]
-                    )
-                    if array_input:
-                        array_inputs.append(input)
+    app_obj = api.apps.get(app)
+    inputs = app_obj.raw["inputs"]
+    for input in inputs:
+        workflow_inputs[input["id"]], array_input = get_input_type(input["type"])
+        if array_input:
+            array_inputs.append(input["id"])
 
-        except yaml.YAMLError as exc:
-            print(exc)
-            exit(1)
     print("Done processing workflow inputs!", file=sys.stderr)
     return workflow_inputs, array_inputs
 
@@ -147,19 +125,13 @@ def parse_workflow_file(workflow_file):
     default="cavatica",
     show_default=True,
 )
-@click.option(
-    "-w",
-    "--workflow_file",
-    type=click.Path(exists=True),
-    help="Path to workflow file",
-)
 @click.option("--out", help="Output files basename", default="new")
 @click.option(
     "--options_file",
     type=click.Path(exists=True),
     help="Path to options file",
 )
-def create_task_script(profile, workflow_file, out, options_file):
+def create_task_script(profile, out, options_file):
     """
     Create a draft task from a workflow cwl and file with task options.
     """
@@ -170,9 +142,6 @@ def create_task_script(profile, workflow_file, out, options_file):
     api = hf.parse_config(profile)
     username = api.users.me().username
 
-    # parse workflow file
-    workflow_inputs, array_inputs = parse_workflow_file(workflow_file)
-
     # parse options file and create tasks
     task_ids = []
     file_ids = {}
@@ -180,6 +149,8 @@ def create_task_script(profile, workflow_file, out, options_file):
     new_cols = ["task_id", "created_by"]
     base_names = {}
     our_app = None
+    workflow_inputs = None
+    array_inputs = None
     with open(options_file, "r") as f:
         line_num = 0
         task_options = []
@@ -213,6 +184,8 @@ def create_task_script(profile, workflow_file, out, options_file):
                     raise ValueError(
                         f"App {app} does not match previous app {our_app}. Please use the same app for all tasks."
                     )
+                if workflow_inputs is None:
+                    workflow_inputs, array_inputs = parse_workflow_app(api, app)
                 project_id = "/".join(app.split("/")[:2])
                 project = hf.parse_project(project_id)
                 # remove app from line_split

--- a/scripts/create_task_from_wf_cwl.py
+++ b/scripts/create_task_from_wf_cwl.py
@@ -111,7 +111,7 @@ def create_task_from_json(
     with open(f"{out}_task_ids.txt", "w") as handle:
         handle.write(f"{new_task.id}\n")
 
-    with open(f"{out}_tasks.tsv", "w", newline="") as handle:
+    with open(f"{out}_options.tsv", "w", newline="") as handle:
         writer = csv.writer(handle, delimiter="\t", lineterminator="\n")
         writer.writerow(
             [

--- a/scripts/create_task_from_wf_cwl.py
+++ b/scripts/create_task_from_wf_cwl.py
@@ -147,7 +147,6 @@ def parse_workflow_file(workflow_file):
     default="cavatica",
     show_default=True,
 )
-@click.option("--app", help="App name, appid field on Cavaita app page")
 @click.option(
     "-w",
     "--workflow_file",
@@ -156,17 +155,11 @@ def parse_workflow_file(workflow_file):
 )
 @click.option("--out", help="Output files basename", default="new")
 @click.option(
-    "--skip_name_check",
-    help="Skip checking if app name and workflow file name match",
-    is_flag=True,
-    default=False,
-)
-@click.option(
     "--options_file",
     type=click.Path(exists=True),
     help="Path to options file",
 )
-def create_task_script(profile, app, workflow_file, out, skip_name_check, options_file):
+def create_task_script(profile, workflow_file, out, options_file):
     """
     Create a draft task from a workflow cwl and file with task options.
     """
@@ -177,16 +170,6 @@ def create_task_script(profile, app, workflow_file, out, skip_name_check, option
     api = hf.parse_config(profile)
     username = api.users.me().username
 
-    project_id = "/".join(app.split("/")[:2])
-    project = hf.parse_project(project_id)
-
-    web_app_name = app.split("/")[-1]
-    file_app_name = workflow_file.split("/")[-1].split(".")[0]
-    if web_app_name != file_app_name:
-        if not skip_name_check:
-            print("App name and workflow file name do not match")
-            exit(1)
-
     # parse workflow file
     workflow_inputs, array_inputs = parse_workflow_file(workflow_file)
 
@@ -194,11 +177,12 @@ def create_task_script(profile, app, workflow_file, out, skip_name_check, option
     task_ids = []
     file_ids = {}
     out_lines = []
-    new_cols = ["app", "task_id", "created_by"]
+    new_cols = ["task_id", "created_by"]
     base_names = {}
     with open(options_file, "r") as f:
         line_num = 0
         task_options = []
+        app_index = None
         for line in f:
             if line_num == 0:
                 # parse header
@@ -209,10 +193,23 @@ def create_task_script(profile, app, workflow_file, out, skip_name_check, option
                         base_names[opt] = {"out_name": f"final_{opt}", "value": None}
                 head_line = f"{head_line}\t{"\t".join(new_cols)}\t{"\t".join([base_names[opt]["out_name"] for opt in base_names])}"
                 out_lines.append(head_line)
+                # find the app index in the task options, then remove it
+                if "app" in task_options:
+                    app_index = task_options.index("app")
+                    task_options.remove("app")
+                else:
+                    raise ValueError(
+                        f"App not in options file header: {head_line}. Please add app column to options file."
+                    )
             else:
                 # create new task reading inputs and converting to expected type
                 task_inputs = {}
                 line_split = line.strip().split("\t")
+                app = line_split[app_index]
+                project_id = "/".join(app.split("/")[:2])
+                project = hf.parse_project(project_id)
+                # remove app from line_split
+                line_split.remove(app)
                 for option in task_options:
                     if option not in workflow_inputs:
                         print(
@@ -268,7 +265,8 @@ def create_task_script(profile, app, workflow_file, out, skip_name_check, option
                                 else:
                                     task_inputs[option][i] = task_inputs[option][i]
 
-                task_name = f"{web_app_name}_{today}"
+                app_name = app.split("/")[2]
+                task_name = f"{app_name}_{today}"
                 if "output_basename" in task_inputs:
                     task_name = f"{task_name}_{task_inputs["output_basename"]}"
                 else:
@@ -296,7 +294,7 @@ def create_task_script(profile, app, workflow_file, out, skip_name_check, option
                 print(f"{new_task.name}, {new_task.status}, {new_task.id}")
                 task_ids.append(new_task.id)
                 out_lines.append(
-                    f"{line.strip()}\t{new_task.app}\t{new_task.id}\t{username}\t{"\t".join([base_names[opt]["value"] for opt in base_names])}"
+                    f"{line.strip()}\t{new_task.id}\t{username}\t{"\t".join([base_names[opt]["value"] for opt in base_names])}"
                 )
 
             line_num += 1

--- a/scripts/create_task_from_wf_cwl.py
+++ b/scripts/create_task_from_wf_cwl.py
@@ -107,7 +107,7 @@ def create_task_from_json(
     with open(f"{out}_task_ids.txt", "w") as handle:
         handle.write(f"{new_task.id}\n")
 
-    with open(f"{out}_tasks.tsv", "w", newline="") as handle:
+    with open(f"{out}_options.tsv", "w", newline="") as handle:
         writer = csv.writer(handle, delimiter="\t", lineterminator="\n")
         writer.writerow(
             [

--- a/scripts/create_task_from_wf_cwl.py
+++ b/scripts/create_task_from_wf_cwl.py
@@ -51,7 +51,7 @@ def parse_app_id(app):
     parts = app.strip("/").split("/")
     if len(parts) not in (3, 4) or not all(parts):
         raise click.UsageError(
-            "--app must use the format user/project/app or user/project/app/revision"
+            "JSON app must use the format user/project/app or user/project/app/revision"
         )
     return "/".join(parts[:2]), parts[2]
 
@@ -69,6 +69,12 @@ def load_task_inputs_json(path):
     if not isinstance(task_inputs, dict):
         raise click.ClickException("Task inputs JSON must contain one JSON object")
 
+    app = task_inputs.pop("app", None)
+    if not isinstance(app, str) or not app.strip():
+        raise click.ClickException(
+            "Task inputs JSON must contain a non-empty string app"
+        )
+
     output_basename = task_inputs.get("output_basename")
     if not isinstance(output_basename, str) or not output_basename.strip():
         raise click.ClickException(
@@ -77,7 +83,7 @@ def load_task_inputs_json(path):
 
     output_basename = output_basename.strip()
     task_inputs["output_basename"] = output_basename
-    return task_inputs, output_basename
+    return task_inputs, app.strip(), output_basename
 
 
 def create_task_from_json(
@@ -221,15 +227,11 @@ def parse_workflow_app(api, app):
     help="Path to options file",
 )
 @click.option(
-    "--app",
-    help="CAVATICA app ID; required with --task-inputs-json",
-)
-@click.option(
     "--task-inputs-json",
     type=click.Path(exists=True, dir_okay=False),
     help="JSON object containing inputs for one CAVATICA task",
 )
-def create_task_script(profile, out, options_file, app, task_inputs_json):
+def create_task_script(profile, out, options_file, task_inputs_json):
     """
     Create draft tasks from TSV options or one structured JSON input object.
     """
@@ -240,14 +242,13 @@ def create_task_script(profile, out, options_file, app, task_inputs_json):
         )
     # Validate JSON before connecting to CAVATICA.
     json_task_inputs = None
+    app = None
     json_output_basename = None
     if task_inputs_json:
-        if not app:
-            raise click.UsageError("--app is required with --task-inputs-json")
-        project_id, web_app_name = parse_app_id(app)
-        json_task_inputs, json_output_basename = load_task_inputs_json(
+        json_task_inputs, app, json_output_basename = load_task_inputs_json(
             task_inputs_json
         )
+        project_id, web_app_name = parse_app_id(app)
 
     today = datetime.datetime.now().strftime("%Y%m%d")
 

--- a/scripts/create_task_from_wf_cwl.py
+++ b/scripts/create_task_from_wf_cwl.py
@@ -86,6 +86,27 @@ def load_task_inputs_json(path):
     return task_inputs, app.strip(), output_basename
 
 
+def validate_json_task_inputs(api, app, task_inputs):
+    """Reject JSON keys that are not inputs for the selected app."""
+    workflow_inputs, _ = parse_workflow_app(api, app)
+    unknown = sorted(set(task_inputs) - set(workflow_inputs))
+    if unknown:
+        raise click.ClickException(
+            "Task inputs contain option(s) not in the CAVATICA app: "
+            + ", ".join(unknown)
+        )
+
+
+def check_task_errors(task):
+    """Fail with the draft ID when CAVATICA reports task validation errors."""
+    task_errors = getattr(task, "errors", None)
+    if isinstance(task_errors, (dict, list, tuple)) and task_errors:
+        raise click.ClickException(
+            f"Draft task {task.id} was created with validation errors: "
+            + json.dumps(task_errors, default=str)
+        )
+
+
 def create_task_from_json(
     api,
     username,
@@ -102,6 +123,7 @@ def create_task_from_json(
     new_task = api.tasks.create(
         name=task_name, project=project, app=app, inputs=task_inputs
     )
+    check_task_errors(new_task)
     final_output_basename = f"{original_output_basename}_{new_task.id}"
 
     try:
@@ -254,9 +276,10 @@ def create_task_script(profile, out, options_file, task_inputs_json):
 
     # get api
     api = hf.parse_config(profile)
-    username = api.users.me().username
 
     if task_inputs_json:
+        validate_json_task_inputs(api, app, json_task_inputs)
+        username = api.users.me().username
         project = hf.parse_project(project_id)
         create_task_from_json(
             api,
@@ -270,6 +293,8 @@ def create_task_script(profile, out, options_file, task_inputs_json):
             today,
         )
         return
+
+    username = api.users.me().username
     # parse options file and create tasks
     task_ids = []
     file_ids = {}
@@ -384,6 +409,7 @@ def create_task_script(profile, out, options_file, task_inputs_json):
                 new_task = api.tasks.create(
                     name=task_name, project=project, app=app, inputs=task_inputs
                 )
+                check_task_errors(new_task)
 
                 # update task now that we have task id
                 if base_names:

--- a/scripts/create_task_from_wf_cwl.py
+++ b/scripts/create_task_from_wf_cwl.py
@@ -179,6 +179,7 @@ def create_task_script(profile, workflow_file, out, options_file):
     out_lines = []
     new_cols = ["task_id", "created_by"]
     base_names = {}
+    our_app = None
     with open(options_file, "r") as f:
         line_num = 0
         task_options = []
@@ -206,6 +207,12 @@ def create_task_script(profile, workflow_file, out, options_file):
                 task_inputs = {}
                 line_split = line.strip().split("\t")
                 app = line_split[app_index]
+                if our_app is None:
+                    our_app = app
+                elif our_app != app:
+                    raise ValueError(
+                        f"App {app} does not match previous app {our_app}. Please use the same app for all tasks."
+                    )
                 project_id = "/".join(app.split("/")[:2])
                 project = hf.parse_project(project_id)
                 # remove app from line_split

--- a/scripts/get_files_in_folder.py
+++ b/scripts/get_files_in_folder.py
@@ -1,0 +1,186 @@
+"""Get the file ids of output files from a list of tasks."""
+
+import configparser
+import json
+import sys
+from pathlib import Path
+
+import click
+import requests
+from sevenbridges.errors import NotFound
+
+from helper_functions import helper_functions as hf
+
+CONTEXT_SETTINGS = dict(help_option_names=["-h", "--help"])
+
+
+def parse_config(profile):
+    """
+    Parse the config file and return the api object.
+    """
+    home = Path.home()
+    config = configparser.ConfigParser()
+    config.read(home / ".sevenbridges/credentials")
+    url = config[profile]["api_endpoint"]
+    token = config[profile]["auth_token"]
+    return [url, token]
+
+
+def get_regular_files(api, initial_files, debug=False):
+    """
+    Get the file ids of output files from a list of tasks.
+    Inputs:
+    - api object
+    - list of file objects
+    Returns:
+    - list of file objects
+    """
+    return list(iter_regular_files(api, initial_files, debug))
+
+
+def iter_regular_files(api, initial_files, debug=False):
+    """Yield regular files while carrying each folder's path through traversal."""
+    yielded_ids = set()
+
+    for file_id in initial_files:
+        try:
+            file_obj = api.files.get(id=file_id)
+        except NotFound:
+            print(f"Can't find {file_id}, file doesn't exist", file=sys.stderr)
+            continue
+
+        if not file_obj.is_folder():
+            if file_obj.id not in yielded_ids:
+                yielded_ids.add(file_obj.id)
+                yield file_obj
+
+            for secondary in file_obj.secondary_files or []:
+                secondary_id = getattr(secondary, "id", secondary)
+                if secondary_id in yielded_ids:
+                    continue
+                try:
+                    secondary_obj = api.files.get(id=secondary_id)
+                except NotFound:
+                    print(
+                        f"Can't find {secondary_id}, file doesn't exist",
+                        file=sys.stderr,
+                    )
+                    continue
+                yielded_ids.add(secondary_obj.id)
+                yield secondary_obj
+            continue
+
+        print(f"Getting files in {file_obj.name}", file=sys.stderr)
+        folders_to_visit = [(file_obj, file_obj.name)]
+        files_processed = 0
+        files_found = 0
+
+        while folders_to_visit:
+            folder, folder_path = folders_to_visit.pop()
+            offset = 0
+
+            while True:
+                page = folder.list_files(limit=hf.LIMIT, offset=offset)
+                received = len(page)
+                if received == 0:
+                    break
+
+                for child in page:
+                    files_processed += 1
+                    child_path = f"{folder_path}/{child.name}"
+                    if child.is_folder():
+                        folders_to_visit.append((child, child_path))
+                    elif child.id not in yielded_ids:
+                        child.name = child_path
+                        yielded_ids.add(child.id)
+                        files_found += 1
+                        yield child
+
+                    if debug and files_processed % 1000 == 0:
+                        print(
+                            f"Processed {files_processed} entries; "
+                            f"found {files_found} files",
+                            file=sys.stderr,
+                        )
+
+                offset += received
+                if offset >= page.total:
+                    break
+
+        print(f"Found {files_found} files", file=sys.stderr)
+
+
+@click.command(context_settings=CONTEXT_SETTINGS, no_args_is_help=True)
+@click.option("--project", help="Project ID")
+@click.option(
+    "--profile",
+    help="Profile to use from credentials file",
+    default="turbo",
+    show_default=True,
+)
+@click.option(
+    "--blacklist",
+    help="Comma separated files with list of file ids to ignore",
+    default=None,
+)
+@click.option("--debug", help="Print some debug messages", is_flag=True, default=False)
+def get_folder_files(profile, project, debug, blacklist):
+    """
+    Get files at the top level of a project, then get files in those folders.
+    This should only be used as a last resort.
+    """
+    # read config file
+    api = hf.parse_config(profile)
+    project = hf.parse_project(project)
+    url, token = parse_config(profile)
+    header = {
+        "X-SBG-Auth-Token": f"{token}",
+        "accept": "application/json",
+    }
+
+    blacklist_files = set(blacklist.split(",")) if blacklist else set()
+    files = []
+
+    file_url = f"{url}/projects/{project}/files?offset=0&limit=50"
+    session = requests.Session()
+    session.headers.update(header)
+    response = session.get(file_url)
+    if response.status_code != 200:
+        print(f"Error getting files from project {project}: {response.text}")
+        exit(1)
+    else:
+        res = response.json()
+        if debug:
+            with open("files_in_project.json", "w") as f:
+                json.dump(res, f, indent=4)
+        files = res["items"]
+        while res["links"] and res["links"][0]["rel"] == "next":
+            file_url = f"{res["links"][0]["href"]}"
+            if debug:
+                print(file_url, file=sys.stderr)
+            response = session.get(file_url)
+            if response.status_code != 200:
+                print(f"Error getting files from project {project}: {response.text}")
+                exit(1)
+            else:
+                res = response.json()
+                files.extend(res["items"])
+
+    files_found = 0
+    print("file_name\tfile_id")
+    for file in files:
+        name = file["name"]
+        id = file["id"]
+        if name not in blacklist_files:
+            print(f"{name}\t{id}", file=sys.stderr)
+            for regular_file in iter_regular_files(api, [id], debug):
+                print(f"{regular_file.name}\t{regular_file.id}")
+                files_found += 1
+
+    print(f"Found {files_found} files to display", file=sys.stderr)
+    if files_found == 0:
+        print("No files found in input folders")
+
+
+if __name__ == "__main__":
+    get_folder_files()

--- a/scripts/helper_functions/helper_functions.py
+++ b/scripts/helper_functions/helper_functions.py
@@ -131,16 +131,13 @@ def get_file_obj(api, project, file_name) -> str:
     Returns:
     - file_obj: api file object
     """
-    print(f"Searching {project} for {file_name}")
     file_obj = None
 
     # first search for the file directly
     files = api.files.query(project=project, names=[file_name])
     if len(files) == 0:
         found_files = []
-        print(
-            f"File {file_name} not found in root dir of {project}, searching within folders"
-        )
+
         # search for the file in the project
 
         # get all files in the project
@@ -213,13 +210,11 @@ def get_all_projects(api):
     """
     Get all projects the user has access to.
     """
-    # print("Finding projects")
     projects = []
     received = LIMIT
     project_page = api.projects.query(limit=LIMIT)
     projects.extend(project_page)
     while received < project_page.total:
-        # print(f"Looking for more projects, found {received}")
         project_page = api.projects.query(limit=LIMIT, offset=received)
         projects.extend(project_page)
         received += LIMIT
@@ -231,13 +226,11 @@ def get_all_billing(api):
     """
     Get all billing groups the user has access to.
     """
-    print("Finding billing groups")
     billings = []
     received = LIMIT
     billing_page = api.billing_groups.query(limit=LIMIT)
     billings.extend(billing_page)
     while received < billing_page.total:
-        print(f"Looking for more projects, found {received}")
         billing_page = api.billing_groups.query(limit=LIMIT, offset=received)
         billings.extend(billing_page)
         received += LIMIT


### PR DESCRIPTION
<!--Hi there, thanks for your contribution! Please take a moment to fill out this template to facilitate the review of your pull request.-->

### Purpose/implementation Section

### Purpose/implementation Section

- Add --task-inputs-json for creating a TIRTL-seq draft task from structured CAVATICA inputs.
- Append the assigned CAVATICA task ID to the Bioassay-based output_basename.
- Support revisioned CAVATICA app IDs.
- Write a task-ID file and credential-free audit TSV.

- Successfully created an aph17 draft task in [`tirtl-dev` CAVATICA project ](https://cavatica.sbgenomics.com/u/childrens-bti/tirtl-dev/tasks/b5947012-4ce8-4d44-9936-6fae1e4cf415/#set-input-data)
- Confirmed the final basename uses aph17_<TASK_ID>. aph17 being the temporary placeholder for BAID. 
- Confirmed the task remained in DRAFT status.

#### What GitHub issue does your pull request address?



### Directions for reviewers. Tell potential reviewers what kind of feedback you are soliciting.

#### Which areas should receive a particularly close look?



#### Is there anything that you want to discuss further?



#### Is the analysis in a mature enough form that the resulting figure(s) and/or table(s) are ready for review?



### Results

#### What types of results are included (e.g., table, figure)?



#### What is your summary of the results?



#### Reproducibility Checklist

<!-- Check all those that apply or remove this section if it is not applicable.-->

- [X] The dependencies required to run the code in this pull request have been added to the project Dockerfile.

#### Documentation Checklist

- [X] This analysis module has a `README` and it is up to date.
- [X] The analytical code is documented and contains comments.
