### PR TITLE
SBG bug fix: update helper function to skip erroneous projects

### DIFF
--- a/scripts/helper_functions/helper_functions.py
+++ b/scripts/helper_functions/helper_functions.py
@@ -1,8 +1,10 @@
 """Helper functions for sbg python api"""
 
 import configparser
+import sys
 from pathlib import Path
 from sevenbridges import Api
+from sevenbridges.errors import SbgError
 from sevenbridges.http.error_handlers import rate_limit_sleeper, maintenance_sleeper
 
 # set api limit for pagination
@@ -209,20 +211,42 @@ def query_tasks(api, **kwargs):
     return tasks
 
 
+def _query_projects_resilient(api, offset, limit):
+    """
+    Fetch one page of api.projects.query(), skipping any individual project
+    the platform can't serialize instead of failing the whole page. Some
+    projects 500 on the full-field expansion the SDK always requests (seen
+    with cavatica/pnoc-dipg-pa-02) - bisect a failing page down to isolate
+    and skip just the broken record(s).
+    """
+    try:
+        return list(api.projects.query(limit=limit, offset=offset))
+    except SbgError as e:
+        if limit == 1:
+            print(
+                f"WARNING: skipping project at offset {offset} "
+                f"(server error: {e.message})",
+                file=sys.stderr,
+            )
+            return []
+        mid = limit // 2
+        return _query_projects_resilient(api, offset, mid) + _query_projects_resilient(
+            api, offset + mid, limit - mid
+        )
+
+
 def get_all_projects(api):
     """
-    Get all projects the user has access to.
+    Get all projects the user has access to. Projects the platform can't
+    serialize are skipped with a warning (see _query_projects_resilient)
+    rather than aborting the whole report.
     """
-    # print("Finding projects")
+    total = api.projects.query(limit=1).total
     projects = []
-    received = LIMIT
-    project_page = api.projects.query(limit=LIMIT)
-    projects.extend(project_page)
-    while received < project_page.total:
-        # print(f"Looking for more projects, found {received}")
-        project_page = api.projects.query(limit=LIMIT, offset=received)
-        projects.extend(project_page)
-        received += LIMIT
+    offset = 0
+    while offset < total:
+        projects.extend(_query_projects_resilient(api, offset, LIMIT))
+        offset += LIMIT
 
     return projects
 


### PR DESCRIPTION
<!--Hi there, thanks for your contribution! Please take a moment to fill out this template to facilitate the review of your pull request.-->

### Purpose/implementation Section

#### What scientific question is your analysis addressing?

## Summary

- `get_all_projects()` in `scripts/helper_functions/helper_functions.py` paginates through `api.projects.query()`, which the SDK always calls with `fields=_all`. One specific legacy project, `cavatica/pnoc-dipg-pa-02`, 500s (`ServerError: Unexpected error has occurred!`, code 9000) whenever any `fields` parameter is requested — confirmed this is data/serialization-specific to that one project, not a credentials or environment issue, since the same request with no `fields` param succeeds, and `api.users.me()` / earlier pages succeed fine.
- Since pagination fetches the full project list in fixed-size pages, hitting this one broken record anywhere in a page killed the entire report for any user, regardless of who owns the project.
- Adds `_query_projects_resilient()`: fetches a page normally, and on `SbgError` bisects the page (halving the limit) to isolate which individual record(s) are unfetchable, skipping just those with a `WARNING` to stderr instead of aborting.
- `get_all_projects()` now drives all pagination through this resilient helper instead of the previous direct `api.projects.query()` calls.

## Test plan

- [x] Reproduced the failure directly against the Cavatica API and bisected it down to `cavatica/pnoc-dipg-pa-02` specifically (fails with `fields=id` or `fields=_all`, succeeds with no `fields` param).
- [x] Ran `scripts/generate_projects_report.py` end-to-end after the fix: exits 0, produces a full report (28 of my own projects listed), and prints two `WARNING: skipping project at offset ...` lines to stderr for the two unfetchable offsets instead of crashing.
- [ ] Reported the underlying server bug to Seven Bridges/Cavatica support so `cavatica/pnoc-dipg-pa-02` can actually be fixed upstream.
