### PR TITLE
Feature/as/speed up task creation

### DIFF
--- a/scripts/create_task_from_wf_cwl.py
+++ b/scripts/create_task_from_wf_cwl.py
@@ -8,7 +8,6 @@ import datetime
 import warnings
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from pathlib import Path
-from sevenbridges import Api
 from helper_functions import helper_functions as hf
 
 CONTEXT_SETTINGS = dict(help_option_names=["-h", "--help"])
@@ -24,7 +23,7 @@ def wrap_file_obj(api, project, cur_input, file_dict, reject_indices=False):
     - api: sevenbridges Api object
     - project: project id
     - cur_input: file name or id
-    - file_dict: dictionary of file names to ids
+    - file_dict: dictionary of file names to file objects
 
     Returns:
     - file_id: file id
@@ -375,19 +374,22 @@ def create_task_script(profile, out, options_file, task_inputs_json):
                     project, _ = parse_app_id(app)
                     all_project_files = hf.get_all_files(api, project)
                     # store all project files in a dictionary for faster lookup
-                    # dictionary form: {file_name: whole file_obj}
+                    # dictionary form: {file_name: [file_obj, ...]}
                     all_project_file_dict = {}
                     for file_obj in all_project_files:
-                        previous_file = all_project_file_dict.get(file_obj.name)
-                        if previous_file is not None:
+                        matching_files = all_project_file_dict.setdefault(
+                            file_obj.name, []
+                        )
+                        if matching_files:
+                            previous_file = matching_files[-1]
                             warnings.warn(
                                 f"Duplicate file name {file_obj.name!r} found for file ids "
-                                f"{previous_file.id} and {file_obj.id}"
+                                f"{previous_file.id} and {file_obj.id}. "
                                 f"This will be an error if a task tries to use {file_obj.name!r} as an input.",
                                 UserWarning,
                                 stacklevel=2,
                             )
-                        all_project_file_dict[file_obj.name] = file_obj
+                        matching_files.append(file_obj)
                 elif our_app != app:
                     raise ValueError(
                         f"App {app} does not match previous app {our_app}. Please use the same app for all tasks."

--- a/scripts/create_task_from_wf_cwl.py
+++ b/scripts/create_task_from_wf_cwl.py
@@ -6,11 +6,13 @@ import json
 import sys
 import datetime
 import time
+from concurrent.futures import ThreadPoolExecutor
 from pathlib import Path
 from sevenbridges import Api
 from helper_functions import helper_functions as hf
 
 CONTEXT_SETTINGS = dict(help_option_names=["-h", "--help"])
+TASK_API_WORKERS = 8
 
 
 def wrap_file_obj(api, project, cur_input, file_dict, reject_indices=False):
@@ -108,6 +110,28 @@ def check_task_errors(task):
             f"Draft task {task.id} was created with validation errors: "
             + json.dumps(task_errors, default=str)
         )
+
+
+def create_task_from_spec(api, task_spec):
+    """Create one draft task from a prepared task specification."""
+    new_task = api.tasks.create(**task_spec)
+    check_task_errors(new_task)
+    return new_task
+
+
+def save_task_outputs(task_and_bases):
+    """Update and save output basenames for one created task."""
+    task, bases = task_and_bases
+    output_values = {}
+    for base in bases:
+        if task.inputs[base] is not None:
+            output_value = f"{task.inputs[base]}_{task.id}"
+        else:
+            output_value = task.id
+        task.inputs[base] = output_value
+        output_values[base] = output_value
+    task.save()
+    return task, output_values
 
 
 def create_task_from_json(
@@ -304,6 +328,7 @@ def create_task_script(profile, out, options_file, task_inputs_json):
     # parse options file and create tasks
     task_ids = []
     out_lines = []
+    task_specs = []
     new_cols = ["task_id", "created_by"]
     all_project_files = {}
     base_names = {}
@@ -418,33 +443,50 @@ def create_task_script(profile, out, options_file, task_inputs_json):
                 else:
                     task_name = f"{task_name}_{line_num}"
 
-                # call api and store task_id
-                new_task = api.tasks.create(
-                    name=task_name, project=project, app=app, inputs=task_inputs
+                task_specs.append(
+                    {
+                        "name": task_name,
+                        "project": project,
+                        "app": app,
+                        "inputs": task_inputs,
+                    }
                 )
-                check_task_errors(new_task)
-
-                # update task now that we have task id
-                if base_names:
-                    for base in base_names:
-                        if new_task.inputs[base] is not None:
-                            base_names[base][
-                                "value"
-                            ] = f"{new_task.inputs[base]}_{new_task.id}"
-                            new_task.inputs[base] = base_names[base]["value"]
-                        else:
-                            base_names[base]["value"] = new_task.id
-                            new_task.inputs[base] = base_names[base]["value"]
-
-                    new_task.save()
-
-                print(f"{new_task.name}, {new_task.status}, {new_task.id}")
-                task_ids.append(new_task.id)
-                out_lines.append(
-                    f"{line.strip()}\t{new_task.id}\t{username}\t{"\t".join([base_names[opt]["value"] for opt in base_names])}"
-                )
+                out_lines.append(line.strip())
 
             line_num += 1
+
+    # Task creation and output updates are independent across rows. map() keeps
+    # results in input order while the API calls run concurrently.
+    if task_specs:
+        worker_count = min(TASK_API_WORKERS, len(task_specs))
+        with ThreadPoolExecutor(max_workers=worker_count) as executor:
+            created_tasks = list(
+                executor.map(
+                    lambda task_spec: create_task_from_spec(api, task_spec), task_specs
+                )
+            )
+
+            if base_names:
+                saved_tasks = list(
+                    executor.map(
+                        save_task_outputs,
+                        ((task, tuple(base_names)) for task in created_tasks),
+                    )
+                )
+            else:
+                saved_tasks = [(task, {}) for task in created_tasks]
+    else:
+        saved_tasks = []
+
+    task_lines = out_lines[:1]
+    for original_line, (new_task, output_values) in zip(out_lines[1:], saved_tasks):
+        print(f"{new_task.name}, {new_task.status}, {new_task.id}")
+        task_ids.append(new_task.id)
+        task_lines.append(
+            f"{original_line}\t{new_task.id}\t{username}\t"
+            + "\t".join(output_values[opt] for opt in base_names)
+        )
+    out_lines = task_lines
 
     # output task ids to file
     task_file = f"{out}_task_ids.txt"

--- a/scripts/create_task_from_wf_cwl.py
+++ b/scripts/create_task_from_wf_cwl.py
@@ -418,9 +418,6 @@ def create_task_script(profile, out, options_file, task_inputs_json):
                 else:
                     task_name = f"{task_name}_{line_num}"
 
-                # for developement only:
-                task_name = f"NEW_{task_name}"
-
                 # call api and store task_id
                 new_task = api.tasks.create(
                     name=task_name, project=project, app=app, inputs=task_inputs

--- a/scripts/create_task_from_wf_cwl.py
+++ b/scripts/create_task_from_wf_cwl.py
@@ -5,7 +5,6 @@ import csv
 import json
 import sys
 import datetime
-import time
 import warnings
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from pathlib import Path

--- a/scripts/create_task_from_wf_cwl.py
+++ b/scripts/create_task_from_wf_cwl.py
@@ -7,7 +7,7 @@ import sys
 import datetime
 import time
 import warnings
-from concurrent.futures import ThreadPoolExecutor
+from concurrent.futures import ThreadPoolExecutor, as_completed
 from pathlib import Path
 from sevenbridges import Api
 from helper_functions import helper_functions as hf
@@ -333,7 +333,7 @@ def create_task_script(profile, out, options_file, task_inputs_json):
 
     username = api.users.me().username
     # parse options file and create tasks
-    task_ids = []
+    task_ids_by_row = {}
     out_lines = []
     task_specs = []
     new_cols = ["task_id", "created_by"]
@@ -473,44 +473,82 @@ def create_task_script(profile, out, options_file, task_inputs_json):
 
             line_num += 1
 
-    # Task creation and output updates are independent across rows. map() keeps
-    # results in input order while the API calls run concurrently.
+    failed_rows = []
+    saved_tasks = {}
+    task_file = f"{out}_task_ids.txt"
+    with open(task_file, "w"):
+        pass
+
+    # Submit all rows concurrently, but handle each result as soon as it is
+    # available so successful IDs are durable even if another row fails.
     if task_specs:
         worker_count = min(TASK_API_WORKERS, len(task_specs))
         with ThreadPoolExecutor(max_workers=worker_count) as executor:
-            created_tasks = list(
-                executor.map(
-                    lambda task_spec: create_task_from_spec(api, task_spec), task_specs
-                )
-            )
+            create_futures = {
+                executor.submit(create_task_from_spec, api, task_spec): index
+                for index, task_spec in enumerate(task_specs)
+            }
+            created_tasks = {}
+            with open(task_file, "a") as task_handle:
+                for future in as_completed(create_futures):
+                    row_index = create_futures[future]
+                    try:
+                        new_task = future.result()
+                    except Exception as exc:
+                        failed_rows.append((row_index, exc))
+                        continue
+                    created_tasks[row_index] = new_task
+                    task_ids_by_row[row_index] = new_task.id
+                    task_handle.write(f"{new_task.id}\n")
+                    task_handle.flush()
 
-            if base_names:
-                saved_tasks = list(
-                    executor.map(
-                        save_task_outputs,
-                        ((task, tuple(base_names)) for task in created_tasks),
-                    )
+            save_futures = {
+                executor.submit(
+                    save_task_outputs,
+                    (task, tuple(base_names)),
+                ): row_index
+                for row_index, task in created_tasks.items()
+                if base_names
+            }
+            if not base_names:
+                saved_tasks = {
+                    row_index: (task, {})
+                    for row_index, task in created_tasks.items()
+                }
+            for future in as_completed(save_futures):
+                row_index = save_futures[future]
+                try:
+                    saved_tasks[row_index] = future.result()
+                except Exception as exc:
+                    failed_rows.append((row_index, exc))
+
+    if failed_rows:
+        failed_file = f"{out}_failed_rows.txt"
+        with open(failed_file, "w") as handle:
+            for row_index, exc in sorted(failed_rows):
+                handle.write(
+                    f"Input row {row_index + 2}: {out_lines[row_index + 1]}\n"
+                    f"Error: {exc}\n\n"
                 )
-            else:
-                saved_tasks = [(task, {}) for task in created_tasks]
-    else:
-        saved_tasks = []
+        raise click.ClickException(
+            f"{len(failed_rows)} task row(s) failed. Successful task IDs were saved to "
+            f"{task_file}; failed rows were saved to {failed_file}."
+        )
 
     task_lines = out_lines[:1]
-    for original_line, (new_task, output_values) in zip(out_lines[1:], saved_tasks):
+    for row_index, original_line in enumerate(out_lines[1:]):
+        new_task, output_values = saved_tasks[row_index]
         print(f"{new_task.name}, {new_task.status}, {new_task.id}")
-        task_ids.append(new_task.id)
         task_lines.append(
             f"{original_line}\t{new_task.id}\t{username}\t"
             + "\t".join(output_values[opt] for opt in base_names)
         )
     out_lines = task_lines
 
-    # output task ids to file
-    task_file = f"{out}_task_ids.txt"
+    # rewrite task IDs in input order after all requests succeed
     with open(task_file, "w") as f:
-        for task_id in task_ids:
-            f.write(f"{task_id}\n")
+        for row_index in sorted(task_ids_by_row):
+            f.write(f"{task_ids_by_row[row_index]}\n")
 
     # rewrite options file with new columns for
     # task id, creator, and updated output basenames

--- a/scripts/create_task_from_wf_cwl.py
+++ b/scripts/create_task_from_wf_cwl.py
@@ -6,6 +6,7 @@ import json
 import sys
 import datetime
 import time
+import warnings
 from concurrent.futures import ThreadPoolExecutor
 from pathlib import Path
 from sevenbridges import Api
@@ -44,11 +45,17 @@ def wrap_file_obj(api, project, cur_input, file_dict, reject_indices=False):
         )
 
     try:
-        return file_dict[cur_input]
+        matching_files = file_dict[cur_input]
     except KeyError as exc:
         raise FileNotFoundError(
             f"ERROR: File {cur_input} not found in project {project}"
         ) from exc
+    if len(matching_files) > 1:
+        file_ids = ", ".join(file_obj.id for file_obj in matching_files)
+        raise ValueError(
+            f"Duplicate file name {cur_input!r} found for file ids {file_ids}"
+        )
+    return matching_files[0]
 
 
 def parse_app_id(app):
@@ -374,9 +381,12 @@ def create_task_script(profile, out, options_file, task_inputs_json):
                     for file_obj in all_project_files:
                         previous_file = all_project_file_dict.get(file_obj.name)
                         if previous_file is not None:
-                            raise ValueError(
+                            warnings.warn(
                                 f"Duplicate file name {file_obj.name!r} found for file ids "
                                 f"{previous_file.id} and {file_obj.id}"
+                                f"This will be an error if a task tries to use {file_obj.name!r} as an input.",
+                                UserWarning,
+                                stacklevel=2,
                             )
                         all_project_file_dict[file_obj.name] = file_obj
                 elif our_app != app:

--- a/scripts/create_task_from_wf_cwl.py
+++ b/scripts/create_task_from_wf_cwl.py
@@ -13,15 +13,16 @@ from helper_functions import helper_functions as hf
 CONTEXT_SETTINGS = dict(help_option_names=["-h", "--help"])
 
 
-def wrap_file_obj(api, project, cur_input, reject_indices=False):
+def wrap_file_obj(api, project, cur_input, file_dict, reject_indices=False):
     """
-    Wrapper function for get_file_obj.
+    Wrapper function to get file id.
     Tries to handle index files
 
     Inputs:
     - api: sevenbridges Api object
     - project: project id
     - cur_input: file name or id
+    - file_dict: dictionary of file names to ids
 
     Returns:
     - file_id: file id
@@ -32,18 +33,20 @@ def wrap_file_obj(api, project, cur_input, reject_indices=False):
     if reject_indices and suff in my_indices:
         main_file = path.stem
         print(f"Found index file {cur_input}, trying to get main file {main_file}")
-        try:
-            # return hf.get_file_obj(api, project, main_file)
-            main_obj = hf.get_file_obj(api, project, main_file)
+        if main_file in file_dict:
             raise ValueError(
                 f"Index file given. Update options file to include {main_file} instead of {cur_input}"
             )
-        except FileNotFoundError as exc:
-            raise ValueError(
-                f"Main file {main_file} for index {cur_input} was not found"
-            ) from exc
+        raise ValueError(
+            f"Main file {main_file} for index {cur_input} was not found"
+        )
 
-    return hf.get_file_obj(api, project, cur_input)
+    try:
+        return file_dict[cur_input]
+    except KeyError as exc:
+        raise FileNotFoundError(
+            f"ERROR: File {cur_input} not found in project {project}"
+        ) from exc
 
 
 def parse_app_id(app):
@@ -300,9 +303,9 @@ def create_task_script(profile, out, options_file, task_inputs_json):
     username = api.users.me().username
     # parse options file and create tasks
     task_ids = []
-    file_ids = {}
     out_lines = []
     new_cols = ["task_id", "created_by"]
+    all_project_files = {}
     base_names = {}
     our_app = None
     workflow_inputs = None
@@ -336,7 +339,13 @@ def create_task_script(profile, out, options_file, task_inputs_json):
                 line_split = line.strip().split("\t")
                 app = line_split[app_index]
                 if our_app is None:
+                    # first time seeing an app, get all files in project and parse workflow inputs
                     our_app = app
+                    project, _ = parse_app_id(app)
+                    all_project_files = hf.get_all_files(api, project)
+                    # store all project files in a dictionary for faster lookup
+                    # dictionary form: {file_name: whole file_obj}
+                    all_project_file_dict = {f.name: f for f in all_project_files}
                 elif our_app != app:
                     raise ValueError(
                         f"App {app} does not match previous app {our_app}. Please use the same app for all tasks."
@@ -357,17 +366,14 @@ def create_task_script(profile, out, options_file, task_inputs_json):
                         if option not in array_inputs:
                             cur_input = line_split[task_options.index(option)]
                             if workflow_inputs[option] == "file":
-                                if cur_input in file_ids:
-                                    task_inputs[option] = file_ids[cur_input]
-                                else:
-                                    my_id = wrap_file_obj(
-                                        api,
-                                        project,
-                                        cur_input,
-                                        option in secondary_files,
-                                    )
-                                    task_inputs[option] = my_id
-                                    file_ids[cur_input] = my_id
+                                my_id = wrap_file_obj(
+                                    api,
+                                    project,
+                                    cur_input,
+                                    all_project_file_dict,
+                                    option in secondary_files,
+                                )
+                                task_inputs[option] = my_id
                             elif workflow_inputs[option] == "bool":
                                 task_inputs[option] = (
                                     cur_input.strip().lower() == "true"
@@ -384,19 +390,14 @@ def create_task_script(profile, out, options_file, task_inputs_json):
                             ].split(",")
                             for i in range(len(task_inputs[option])):
                                 if workflow_inputs[option] == "file":
-                                    if task_inputs[option][i] in file_ids:
-                                        task_inputs[option][i] = file_ids[
-                                            task_inputs[option][i]
-                                        ]
-                                    else:
-                                        my_id = wrap_file_obj(
-                                            api,
-                                            project,
-                                            task_inputs[option][i],
-                                            option in secondary_files,
-                                        )
-                                        file_ids[task_inputs[option][i]] = my_id
-                                        task_inputs[option][i] = my_id
+                                    my_id = wrap_file_obj(
+                                        api,
+                                        project,
+                                        task_inputs[option][i],
+                                        all_project_file_dict,
+                                        option in secondary_files,
+                                    )
+                                    task_inputs[option][i] = my_id
                                 elif workflow_inputs[option] == "bool":
                                     task_inputs[option][i] = (
                                         task_inputs[option][i].strip().lower() == "true"
@@ -416,6 +417,9 @@ def create_task_script(profile, out, options_file, task_inputs_json):
                     task_name = f"{task_name}_{task_inputs["output_basename"]}"
                 else:
                     task_name = f"{task_name}_{line_num}"
+
+                # for developement only:
+                task_name = f"NEW_{task_name}"
 
                 # call api and store task_id
                 new_task = api.tasks.create(

--- a/scripts/create_task_from_wf_cwl.py
+++ b/scripts/create_task_from_wf_cwl.py
@@ -370,7 +370,15 @@ def create_task_script(profile, out, options_file, task_inputs_json):
                     all_project_files = hf.get_all_files(api, project)
                     # store all project files in a dictionary for faster lookup
                     # dictionary form: {file_name: whole file_obj}
-                    all_project_file_dict = {f.name: f for f in all_project_files}
+                    all_project_file_dict = {}
+                    for file_obj in all_project_files:
+                        previous_file = all_project_file_dict.get(file_obj.name)
+                        if previous_file is not None:
+                            raise ValueError(
+                                f"Duplicate file name {file_obj.name!r} found for file ids "
+                                f"{previous_file.id} and {file_obj.id}"
+                            )
+                        all_project_file_dict[file_obj.name] = file_obj
                 elif our_app != app:
                     raise ValueError(
                         f"App {app} does not match previous app {our_app}. Please use the same app for all tasks."

--- a/scripts/get_all_files_project.py
+++ b/scripts/get_all_files_project.py
@@ -1,0 +1,37 @@
+"""Simple script to get all files in a project"""
+
+import click
+import time
+from sevenbridges import Api
+from helper_functions import helper_functions as hf
+
+CONTEXT_SETTINGS = dict(help_option_names=["-h", "--help"])
+
+@click.command(context_settings=CONTEXT_SETTINGS, no_args_is_help=True)
+@click.option("--project", help="Project ID")
+@click.option(
+    "--profile",
+    help="Profile to use from credentials file",
+    default="turbo",
+    show_default=True,
+)
+@click.option(
+    "--output_file",
+    help="Output file to save the list of files",
+    default="all_files.txt",
+    show_default=True,
+)
+def get_all_files_project(project, profile, output_file):
+    """Find a file in a project"""
+    # read config file
+    api = hf.parse_config(profile)
+    project = hf.parse_project(project)
+    print(f"Getting all files in project {project}")
+    files = hf.get_all_files(api, project)
+
+    with open(output_file, "w", encoding="utf-8") as file:
+        file.write("Name\tid\n")
+        file.writelines(f"{item.name}\t{item.id}\n" for item in files)
+
+if __name__ == "__main__":
+    get_all_files_project()

--- a/scripts/get_all_files_project.py
+++ b/scripts/get_all_files_project.py
@@ -33,5 +33,8 @@ def get_all_files_project(project, profile, output_file):
         file.write("Name\tid\n")
         file.writelines(f"{item.name}\t{item.id}\n" for item in files)
 
+    print(len(files))
+    print(len({f.id for f in files}))
+
 if __name__ == "__main__":
     get_all_files_project()

--- a/scripts/helper_functions/helper_functions.py
+++ b/scripts/helper_functions/helper_functions.py
@@ -27,13 +27,13 @@ def get_all_files_folder(api, folder) -> list:
         raise ValueError(f"ERROR: File {folder.name} is not a folder")
     
     # get all of the files in a folder
-    all_files.extend(folder.list_files(limit=LIMIT))
-    keep_going = True
-    while keep_going:
-        folder_files = folder.list_files(limit=LIMIT, offset=len(all_files))
+    folder_files = folder.list_files(limit=LIMIT)
+    all_files.extend(folder_files)
+    received = LIMIT
+    while received < folder_files.total:
+        folder_files = folder.list_files(limit=LIMIT, offset=received)
         all_files.extend(folder_files)
-        if len(all_files) >= folder_files.total:
-            keep_going = False
+        received += LIMIT
 
     # check if any of the files are a folder
     for file in all_files:
@@ -43,6 +43,7 @@ def get_all_files_folder(api, folder) -> list:
             all_files.extend(folder_files)
             while received < folder_files.total:
                 folder_files = file.list_files(limit=LIMIT, offset=received)
+                all_files.extend(folder_files)
                 received += LIMIT
 
     return all_files
@@ -79,6 +80,7 @@ def get_all_files(api, project) -> list:
             all_files.extend(folder_files)
             while received < folder_files.total:
                 folder_files = file.list_files(limit=LIMIT, offset=received)
+                all_files.extend(folder_files)
                 received += LIMIT
 
     return all_files

--- a/scripts/helper_functions/helper_functions.py
+++ b/scripts/helper_functions/helper_functions.py
@@ -55,7 +55,7 @@ def get_all_files(api, project) -> list:
     - api: api obejct
     - project: project name
     Returns:
-    -
+    - list of file objects in the project and subfolders
     """
     all_files = []
 

--- a/scripts/helper_functions/helper_functions.py
+++ b/scripts/helper_functions/helper_functions.py
@@ -63,19 +63,12 @@ def get_all_files(api, project) -> list:
     project_obj = api.projects.get(id=project)
 
     # query project for all files using pagination
-    received = LIMIT
     project_files = project_obj.get_files(limit=LIMIT)
     all_files.extend(project_files)
-    keep_going = True
-    last_id = all_files[-1].id
-    # while received < project_files.total:
-    while keep_going:
+    received = LIMIT
+    while received < project_files.total:
         project_files = project_obj.get_files(limit=LIMIT, offset=received)
         all_files.extend(project_files)
-        if all_files[-1].id == last_id:
-            keep_going = False
-        else:
-            last_id = all_files[-1].id
         received += LIMIT
 
     # check if any of the files are a folder


### PR DESCRIPTION
Partially closes: #222 (I still think there's more to do for this, but this is a good start)

This PR changes to create_task script to only query files once instead of querying every file individually and only caching the ones we've used.

Testing:

To test this, I redrafted tasks from gilbert-itt-1050 locally using the current and updated code and used `time` to record the time. I then manually inspected the drafted tasks to ensure the tasks were set up the same.

Options File: [gilbert-itt-1050-input.tsv](https://github.com/user-attachments/files/31310111/gilbert-itt-1050-input.tsv)
Drafted Tasks: https://cavatica.sbgenomics.com/u/childrens-bti/gilbert-itt-1050/tasks

Results:
```
# Dev version:
python scripts/create_task_from_wf_cwl.py --profile turbo --options_file     0.43s user 0.08s system 0% cpu 1:00.45 total

# Current main version:
python scripts/create_task_from_wf_cwl.py --profile turbo --options_file     5.82s user 0.58s system 4% cpu 2:12.84 total

# Parrallel run:
python scripts/create_task_from_wf_cwl.py --profile turbo --options_file     0.45s user 0.11s system 3% cpu 16.567 total
```

This was a little over 50 % speed improvement. This should be a much bigger number with a larger number of tasks and this should also avoid the weird duplicate files errors we're seeing when drafting pbta autogvp tasks.

Creating the tasks in parallel is a speed up of about 88 %.